### PR TITLE
Upated StrToStrings and StrIToStrings procedures in JclStrings.pas

### DIFF
--- a/jcl/source/common/JclStrings.pas
+++ b/jcl/source/common/JclStrings.pas
@@ -3328,8 +3328,8 @@ begin
       Delete(S, 1, I + L - 1);
       I := Pos(Sep, S);
     end;
-    if S <> '' then
-      List.Add(S);  // Ignore empty strings at the end.
+    if (S <> '') or AllowEmptyString then
+      List.Add(S);  // Ignore empty strings at the end (only if AllowEmptyString = False).
   finally
     List.EndUpdate;
   end;
@@ -3358,8 +3358,8 @@ begin
       Delete(LowerCaseStr, 1, I + L - 1);
       I := Pos(Sep, LowerCaseStr);
     end;
-    if S <> '' then
-      List.Add(S);  // Ignore empty strings at the end.
+    if (S <> '') or AllowEmptyString then
+      List.Add(S);  // Ignore empty strings at the end (only if AllowEmptyString = False).
   finally
     List.EndUpdate;
   end;


### PR DESCRIPTION
Upated StrToStrings and StrIToStrings procedures in JclStrings.pas to correctly handle empty strings at the end when AllowEmptyString = True
