### PR TITLE
Fix Integer Over/Underflow in DynArrayCompareInteger

### DIFF
--- a/jcl/source/common/JclSysUtils.pas
+++ b/jcl/source/common/JclSysUtils.pas
@@ -1581,7 +1581,13 @@ end;
 
 function DynArrayCompareInteger(Item1, Item2: Pointer): Integer;
 begin
-  Result := PInteger(Item1)^ - PInteger(Item2)^;
+  if PInteger(Item1)^ < PInteger(Item2)^ then
+    Result := -1
+  else
+  if PInteger(Item1)^ > PInteger(Item2)^ then
+    Result := 1
+  else
+    Result := 0;
 end;
 
 function DynArrayCompareCardinal(Item1, Item2: Pointer): Integer;


### PR DESCRIPTION
If PInteger(Item1)^ = High(Integer) and PInteger(Item2)^ < 0 then
PInteger(Item1)^ - PInteger(Item2) will overflow and dependant on
{$OverFlowChecks} directive either crash or give wrong ordering. Use safe
compare function also used for other types that don't fit inside Integer
