### PR TITLE
Set Anchors on "Install selected only"

### DIFF
--- a/jcl/install/VclGui/JediGUIMain.dfm
+++ b/jcl/install/VclGui/JediGUIMain.dfm
@@ -353,6 +353,7 @@ object MainForm: TMainForm
     Top = 551
     Width = 129
     Height = 17
+    Anchors = [akRight, akBottom]
     Caption = 'RsGUIInstallSelectedOnly'
     TabOrder = 6
     Visible = False


### PR DESCRIPTION
Correctly set the Anchors property on the "Install selected only"
checkbox so that it repositions as expected when the form is resized.