### PR TITLE
Fixed incorrect address calculation in PeMapImgResolvePackageThunk function in 64bit mode

### DIFF
--- a/jcl/source/windows/JclPeImage.pas
+++ b/jcl/source/windows/JclPeImage.pas
@@ -6255,7 +6255,12 @@ type
   PPackageThunk = ^TPackageThunk;
   TPackageThunk = packed record
     JmpInstruction: Word;
+  {$IFDEF CPU32}
     JmpAddress: PPointer;
+  {$ENDIF CPU32}
+  {$IFDEF CPU64}
+    JmpOffset: Int32;
+  {$ENDIF CPU64}
   end;
 begin
   if not IsCompiledWithPackages then
@@ -6263,7 +6268,13 @@ begin
   else
   if not IsBadReadPtr(Address, SizeOf(TPackageThunk)) and
     (PPackageThunk(Address)^.JmpInstruction = JmpInstructionCode) then
+  {$IFDEF CPU32}
     Result := PPackageThunk(Address)^.JmpAddress^
+  {$ENDIF CPU32}
+  {$IFDEF CPU64}
+    Result := PPointer(PByte(Address) + SizeOf(TPackageThunk) +
+      PPackageThunk(Address)^.JmpOffset)^
+  {$ENDIF CPU64}
   else
     Result := nil;
 end;


### PR DESCRIPTION
PeMapImgResolvePackageThunk  function raises access violation in 64bit application compiled with packages.

This is because Jmp instruction in 64bit code works differently than in 32bit code. 
Here is SO question with more details: 
http://stackoverflow.com/questions/7644508/how-to-interpret-jmp-dword-ptr-rel-00005e52

With this fix applied PeMapImgResolvePackageThunk  doesn't raise access violation  and returns correct address.