### PR TITLE
TJclWideRegEx.GetCaptureName must only add 1 to the PWideChar.

### DIFF
--- a/jcl/source/common/JclPCRE.pas
+++ b/jcl/source/common/JclPCRE.pas
@@ -1186,7 +1186,7 @@ begin
   PCRECheck(pcre16_fullinfo(FCode, FExtra, PCRE_INFO_NAMETABLE, @NameTable), SupportsWideChar);
   PCRECheck(pcre16_fullinfo(FCode, FExtra, PCRE_INFO_NAMEENTRYSIZE, @EntrySize), SupportsWideChar);
 
-  NameTable := NameTable + EntrySize * Index + 2;
+  NameTable := NameTable + EntrySize * Index + 1;
   Result := DecodeWideString(WideString(NameTable), roUTF16 in Options);
 end;
 


### PR DESCRIPTION
PCRE_INFO_NAMETABLE: In the 16-bit library, the pointer points to 16-bit data units, the first of which contains the parenthesis number.
(http://www.pcre.org/original/doc/html/pcreapi.html)