### PR TITLE
Added switches to BCC options to locate hpp files in custom directories

### DIFF
--- a/jcl/install/JclInstall.pas
+++ b/jcl/install/JclInstall.pas
@@ -1672,6 +1672,7 @@ var
           Target.BCC.Options.Add('-w-par'); // warning
           Target.BCC.Options.Add('-w-aus'); // warning
           Target.BCC.AddPathOption('I', Format('%s%s%s%sinclude%s%s', [Distribution.JclSourcePath, DirSeparator, Target.RootDir, DirDelimiter, DirSeparator, Target.VclIncludeDir[FTargetPlatform]]));
+          Target.BCC.AddPathOption('I', ExcludeTrailingPathDelimiter(GetHppPath));
         end
         else
         begin
@@ -1693,6 +1694,7 @@ var
 
           Target.BCC.Options.Add('-I "' + Distribution.JclSourcePath + '"');
           Target.BCC.Options.Add('-I "' + Target.RootDir + '"');
+          Target.BCC.Options.Add('-I "' + ExcludeTrailingPathDelimiter(GetHppPath) + '"');
           Target.BCC.Options.Add('-isystem "' + Target.VclIncludeDir[FTargetPlatform] + '"');
         end;
         Options := StringsToStr(Target.BCC.Options, NativeSpace);


### PR DESCRIPTION
During installation, if "Check HPP files" is checked and "HPP path" is set to point to a custom path (i.e. something different from BDS standard include path), compilation of jcl_a2z.cpp and jcl_z2a.cpp fails.
This is due to the custom path not being passed to the bcc compiler using the -I option.