### PR TITLE
Add git multiple worktree and submodule support to the "Version Control" menu

### DIFF
--- a/jcl/source/vcl/JclVersionCtrlGITImpl.pas
+++ b/jcl/source/vcl/JclVersionCtrlGITImpl.pas
@@ -99,6 +99,7 @@ const
   JclVersionCtrlGITDirectory1 = '.git\';
   JclVersionCtrlGITIndexFile = 'index';
   JclVersionCtrlGITIgnoreFile = '.gitignore';
+  JclVersionCtrlGITLinkFile = '.git';
 
   JclVersionCtrlGITDirectories: array [0 .. 0] of string = (JclVersionCtrlGITDirectory1);
 
@@ -251,7 +252,14 @@ begin
             Result := DirectoryName;
             Exit;
           end;
+
+        //Account for submodules and multiple worktree's
+        if FileExists(DirectoryName + JclVersionCtrlGITLinkFile) then
+        begin
+          Result := DirectoryName;
+          Exit;
         end;
+      end;
 end;
 
 function TJclVersionControlGIT.GetName: string;
@@ -290,6 +298,14 @@ begin
               Found := True;
               break;
             end;
+
+          if FileExists(DirectoryName + DirDelimiter + JclVersionCtrlGITLinkFile) then
+          begin
+            // When the first .git file is found stop searching
+            Found := True;
+            Break;
+          end;
+
         end;
         if not Found then // if no direcory is found delete the list
           SdBxNames.Clear;


### PR DESCRIPTION
Starting in git 2.5, the "git worktree" command was added which added support for multiple git worktrees attached to one existing git repository.  Yes I realize that "git worktree" is still experimental.

This pull request adds support for utilizing the Version Control menu for repositories that are additional worktrees.  Without this pull request, the various menus are disabled... ie. Blame, Commit, Log, ... are all grayed out.

One caveat to this pull request is that "git worktree" is not yet supported by tortoise git because it is not yet supported by [libgit2](https://github.com/libgit2/libgit2/pull/3436), however, there is a [pull request](https://gitlab.com/tortoisegit/tortoisegit/merge_requests/62) in place that has it fully functional in TortoiseGit.