### PR TITLE
Use relative url in gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "jcl/source/include/jedi"]
 	path = jcl/source/include/jedi
-	url = https://github.com/project-jedi/jedi.git
+	url = ../jedi.git
 	branch = master


### PR DESCRIPTION
Using a relative url allows for ssh cloning of the submodule and better mirroring on other servers.