### PR TITLE
Fixes for 64bit Windows and Delphi 10.2/10.3

### DIFF
--- a/jcl/experts/debug/converter/JclDebugIdeImpl.pas
+++ b/jcl/experts/debug/converter/JclDebugIdeImpl.pas
@@ -605,6 +605,9 @@ var
 begin
   if FBuildError or (Length(FResultInfo) = 0) then
     Exit;
+  if Assigned(Settings) and (Settings.LoadBool(JclDebugQuietSetting, false)) then
+    Exit;
+
   with TJclDebugResultForm.Create(Application, Settings) do
   try
     for I := 0 to Length(FResultInfo) - 1 do

--- a/jcl/experts/debug/converter/JclDebugIdeResult.pas
+++ b/jcl/experts/debug/converter/JclDebugIdeResult.pas
@@ -34,7 +34,7 @@ uses
   {$IFDEF UNITVERSIONING}
   JclUnitVersioning,
   {$ENDIF UNITVERSIONING}
-  JclOtaUtils;
+  JclOtaUtils{$IFDEF HAS_UNITSCOPE}, System.ImageList{$ENDIF};
 
 type
   TJclDebugResultForm = class(TForm)

--- a/jcl/source/vcl/JclGraphUtils.pas
+++ b/jcl/source/vcl/JclGraphUtils.pas
@@ -380,7 +380,7 @@ var
 begin
   ErrorCode := GetLastError;
   if (ErrorCode <> 0) and (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, nil,
-    ErrorCode, LOCALE_USER_DEFAULT, Buf, SizeOf(Buf), nil) <> 0) then
+    ErrorCode, LOCALE_USER_DEFAULT, Buf, Length(Buf), nil) <> 0) then
     raise EOutOfResources.Create(Buf)
   else
     OutOfResources;


### PR DESCRIPTION
-changed procedure GDIError to use Length instead of SizeOf so it work correctly when Char is WideChar
-fixed JclDebug to work correctly when 64bit system has more than 4GB memory
-fixed to work correctly in Delphi 10.2/10.3 