### PR TITLE
Fix for wrongly declared parameter in SnmpUtilOidFree WinAPI import

### DIFF
--- a/jcl/source/windows/Snmp.pas
+++ b/jcl/source/windows/Snmp.pas
@@ -362,7 +362,7 @@ var
   SnmpUtilOidAppend: function(pOidDst: PAsnObjectIdentifier; pOidSrc: PAsnObjectIdentifier): SNMPAPI; stdcall;
   SnmpUtilOidNCmp: function(pOid1, pOid2: PAsnObjectIdentifier; nSubIds: UINT): SNMPAPI; stdcall;
   SnmpUtilOidCmp: function(pOid1, pOid2: PAsnObjectIdentifier): SNMPAPI; stdcall;
-  SnmpUtilOidFree: procedure(pOid: TAsnObjectIdentifier); stdcall;
+  SnmpUtilOidFree: procedure(pOid: PAsnObjectIdentifier); stdcall;
   SnmpUtilOctetsCmp: function(pOctets1, pOctets2: PAsnOctetString): SNMPAPI; stdcall;
   SnmpUtilOctetsNCmp: function(pOctets1, pOctets2: PAsnOctetString; nChars: UINT): SNMPAPI; stdcall;
   SnmpUtilOctetsCpy: function(pOctetsDst, pOctetsSrc: PAsnOctetString): SNMPAPI; stdcall;


### PR DESCRIPTION
Fix for this report:
http://issuetracker.delphi-jedi.org/view.php?id=6649