### PR TITLE
Archive.CurrentItemIndex may return 0 in DoProgress when Archive.ItemCount is zero in TJclCompressionArchive

### DIFF
--- a/jcl/source/common/JclCompression.pas
+++ b/jcl/source/common/JclCompression.pas
@@ -4989,6 +4989,7 @@ end;
 procedure TJclCompressionArchive.ClearItems;
 begin
   FItems.Clear;
+  FCurrentItemIndex := -1;
 end;
 
 procedure TJclCompressionArchive.ClearOperationSuccess;


### PR DESCRIPTION
Fix for this one: http://issuetracker.delphi-jedi.org/view.php?id=6647