### PR TITLE
Fix for JclFileUtils ParamValue always performing case inseisitive search

### DIFF
--- a/jcl/source/common/JclFileUtils.pas
+++ b/jcl/source/common/JclFileUtils.pas
@@ -6996,7 +6996,8 @@ begin
   begin
     pName := ParamName(i, Separator, AllowedPrefixCharacters, True);
     if (CaseSensitive and (pName = Trim(SearchName))) or
-       (UpperCase(pName) = Trim(UpperCase(SearchName))) then
+       ((not CaseSensitive) and
+       (UpperCase(pName) = Trim(UpperCase(SearchName)))) then
     begin
       Result := ParamValue (i, Separator, TrimValue);
       exit;


### PR DESCRIPTION
Proposed fix for the ParamValue part of this one:
http://issuetracker.delphi-jedi.org/view.php?id=6621