### PR TITLE
Fixed duplicate GUIIDs of IJclAnsiStrIntfMap and IJclAnsiStrAnsiStrMap

### DIFF
--- a/jcl/source/common/JclContainerIntf.pas
+++ b/jcl/source/common/JclContainerIntf.pas
@@ -2873,7 +2873,7 @@ type
   end;
 
   IJclAnsiStrAnsiStrMap = interface(IJclAnsiStrContainer)
-    ['{A4788A96-281A-4924-AA24-03776DDAAD8A}']
+    ['{B01D6C80-E120-4BC2-AA93-3DEE18A19B7A}']
     procedure Clear;
     function ContainsKey(const Key: AnsiString): Boolean;
     function ContainsValue(const Value: AnsiString): Boolean;


### PR DESCRIPTION
Fixed http://issuetracker.delphi-jedi.org/view.php?id=6557 by assigning IJclAnsiStrAnsiStrMap a new GUIID