### PR TITLE
Fixed duplicate GUIID of IJclPtrArray and IJclExtendedArray

### DIFF
--- a/jcl/source/common/JclContainerIntf.pas
+++ b/jcl/source/common/JclContainerIntf.pas
@@ -2485,7 +2485,7 @@ type
   end;
 
   IJclExtendedArray = interface(IJclExtendedList)
-    ['{D43E8D18-26B3-41A2-8D52-ED7EA2FE1AB7}']
+    ['{A3693A89-3E57-41B3-9A92-F6CBB64F89AB}']
     function GetValue(Index: Integer): Extended;
     procedure SetValue(Index: Integer; const AValue: Extended);
     property Values[Index: Integer]: Extended read GetValue write SetValue; default;


### PR DESCRIPTION
Fixed the additional duplicate GUIID mentioned in:
http://issuetracker.delphi-jedi.org/view.php?id=6557
by assigning a new GUIID to IJclExtendedArray