### PR TITLE
TJclZipCompressArchive.GetSupportedCompressionMethods missing cmPPMd 

### DIFF
--- a/jcl/source/common/JclCompression.pas
+++ b/jcl/source/common/JclCompression.pas
@@ -9421,7 +9421,7 @@ end;
 
 function TJclZipUpdateArchive.GetSupportedCompressionMethods: TJclCompressionMethods;
 begin
-  Result := [cmCopy,cmDeflate,cmDeflate64,cmBZip2,cmLZMA];
+  Result := [cmCopy,cmDeflate,cmDeflate64,cmBZip2,cmLZMA,cmPPMd];
 end;
 
 function TJclZipUpdateArchive.GetSupportedEncryptionMethods: TJclEncryptionMethods;


### PR DESCRIPTION
Strangely there is a comment on the issue claiming that this value had been added in an earlier commit already. Here it is again.
http://issuetracker.delphi-jedi.org/view.php?id=5464