### PR TITLE
Support for different DLL name in 64 bit applications

### DIFF
--- a/jcl/source/windows/sevenzip.pas
+++ b/jcl/source/windows/sevenzip.pas
@@ -657,7 +657,11 @@ function SetLargePageMode: HRESULT; stdcall;
 //DOM-IGNORE-END
 
 const
+  {$IFDEF Win32}
   SevenzipDefaultLibraryName = '7z.dll';
+  {$ELSE}
+  SevenzipDefaultLibraryName = '7z64.dll';
+  {$ENDIF}
   CreateObjectDefaultExportName = 'CreateObject';
   GetHandlerProperty2DefaultExportName = 'GetHandlerProperty2';
   GetHandlerPropertyDefaultExportName = 'GetHandlerProperty';


### PR DESCRIPTION
Suggested fix from Mantis issue: http://issuetracker.delphi-jedi.org/view.php?id=6573