### PR TITLE
 Installer incorrectly saves C++ browsing paths in BDS 2006 and up 

### DIFF
--- a/jcl/source/common/JclIDEUtils.pas
+++ b/jcl/source/common/JclIDEUtils.pas
@@ -980,7 +980,7 @@ const
 
   LibraryKeyName             = 'Library';
   LibrarySearchPathValueName = 'Search Path';
-  LibraryBrowsingPathValueName = 'Browsing Path';
+  LibraryBrowsingPathValueName = 'BrowsingPath';
   LibraryBPLOutputValueName  = 'Package DPL Output';
   LibraryDCPOutputValueName  = 'Package DCP Output';
   BDSDebugDCUPathValueName   = 'Debug DCU Path';


### PR DESCRIPTION
http://issuetracker.delphi-jedi.org/view.php?id=6398