### PR TITLE
Suggested fix for getting the correct registry key for XE2 C++ and up…

### DIFF
--- a/jcl/source/common/JclIDEUtils.pas
+++ b/jcl/source/common/JclIDEUtils.pas
@@ -987,6 +987,7 @@ const
 
   CppPathsKeyName            = 'CppPaths';
   CppPathsV5UpperKeyName     = 'C++\Paths';
+  CppPathsV9UpperKeyName     = 'C++\Paths\Win32';
   CppBrowsingPathValueName   = 'BrowsingPath';
   CppSearchPathValueName     = 'SearchPath';
   CppLibraryPathValueName    = 'LibraryPath';
@@ -3689,7 +3690,12 @@ end;
 function TJclBDSInstallation.GetCppPathsKeyName: string;
 begin
   if IDEVersionNumber >= 5 then
-    Result := CppPathsV5UpperKeyName
+  begin
+    if IDEVersionNumber >= 9 then
+      Result := CppPathsV9UpperKeyName
+    else
+      Result := CppPathsV5UpperKeyName
+  end
   else
     Result := CppPathsKeyName;
 end;


### PR DESCRIPTION
… as of Mantis issue 6394
http://issuetracker.delphi-jedi.org/view.php?id=6394
The discussion here gives the impression that \Win32 is needed in the C++ XE2 and above registry key.