### PR TITLE
Fix memory corruption in the array list (TJclArrayList<T>) iterator.

### DIFF
--- a/jcl/source/common/JclArrayLists.pas
+++ b/jcl/source/common/JclArrayLists.pas
@@ -1136,12 +1136,12 @@ type
   private
     FCursor: Integer;
     FStart: TItrStart;
-    FOwnList: IJclList<T>;
+    FOwnList: TJclArrayList<T>;
   protected
     procedure AssignPropertiesTo(Dest: TJclAbstractIterator); override;
     function CreateEmptyIterator: TJclAbstractIterator; override;
   public
-    constructor Create(AOwnList: IJclList<T>; ACursor: Integer; AValid: Boolean; AStart: TItrStart);
+    constructor Create(AOwnList: TJclArrayList<T>; ACursor: Integer; AValid: Boolean; AStart: TItrStart);
     { IJclIterator<T> }
     function Add(const AItem: T): Boolean;
     procedure Extract;
@@ -11812,7 +11812,7 @@ end;
 
 //=== { TJclArrayIterator<T> } ===============================================================
 
-constructor TJclArrayIterator<T>.Create(AOwnList: IJclList<T>; ACursor: Integer; AValid: Boolean; AStart: TItrStart);
+constructor TJclArrayIterator<T>.Create(AOwnList: TJclArrayList<T>; ACursor: Integer; AValid: Boolean; AStart: TItrStart);
 begin
   inherited Create(AValid);
   FOwnList := AOwnList;

--- a/jcl/source/prototypes/JclArrayLists.pas
+++ b/jcl/source/prototypes/JclArrayLists.pas
@@ -74,7 +74,7 @@ protected
     TArrayIterator = TJclArrayIterator<T>;
   {$JPPDEFINE GENERIC}{$JPPEXPANDMACRO MOVEARRAYINT(MoveArray,TDynArray,)},,; AOwnsItems: Boolean,const ,AItem,T,GetItem,SetItem)*)
 
-  {$JPPEXPANDMACRO JCLARRAYLISTITRINT(TJclArrayIterator<T>,IJclIterator<T>,IJclList<T>,const ,AItem,T,GetItem,SetItem)}
+  {$JPPEXPANDMACRO JCLARRAYLISTITRINT(TJclArrayIterator<T>,IJclIterator<T>,TJclArrayList<T>,const ,AItem,T,GetItem,SetItem)}
 
   // E = External helper to compare items for equality
   // GetHashCode is not used
@@ -167,7 +167,7 @@ uses
 
 {$JPPDEFINE GENERIC}{$JPPEXPANDMACRO MOVEARRAYIMP(MoveArray,TDynArray,Default(T),TJclArrayList<T>.,)}
 
-{$JPPEXPANDMACRO JCLARRAYLISTITRIMP(TJclArrayIterator<T>,IJclIterator<T>,IJclList<T>,const ,AItem,T,GetItem,SetItem)}
+{$JPPEXPANDMACRO JCLARRAYLISTITRIMP(TJclArrayIterator<T>,IJclIterator<T>,TJclArrayList<T>,const ,AItem,T,GetItem,SetItem)}
 
 //=== { TJclArrayListE<T> } ==================================================
 


### PR DESCRIPTION
Ensure the array list (TJclArrayList<T>) iterator does not inadvertently free the parent array list if the parent array list is only referenced through an object reference instead of an interface reference.