### PR TITLE
Fix memory corruption in the linked list (TJclLinkedList<T>) iterator.

### DIFF
--- a/jcl/source/common/JclLinkedLists.pas
+++ b/jcl/source/common/JclLinkedLists.pas
@@ -1210,13 +1210,13 @@ type
   private
     FCursor: TJclLinkedList<T>.TLinkedListItem;
     FStart: TItrStart;
-    FOwnList: IJclList<T>;
+    FOwnList: TJclLinkedList<T>;
     FEqualityComparer: IJclEqualityComparer<T>;
   public
     procedure AssignPropertiesTo(Dest: TJclAbstractIterator); override;
     function CreateEmptyIterator: TJclAbstractIterator; override;
   public
-    constructor Create(AOwnList: IJclList<T>; ACursor: TJclLinkedList<T>.TLinkedListItem; AValid: Boolean; AStart: TItrStart);
+    constructor Create(AOwnList: TJclLinkedList<T>; ACursor: TJclLinkedList<T>.TLinkedListItem; AValid: Boolean; AStart: TItrStart);
     { IJclIterator<T> }
     function Add(const AItem: T): Boolean;
     procedure Extract;
@@ -17313,7 +17313,7 @@ end;
 
 //=== { TJclLinkedListIterator<T> } ============================================================
 
-constructor TJclLinkedListIterator<T>.Create(AOwnList: IJclList<T>; ACursor: TJclLinkedList<T>.TLinkedListItem; AValid: Boolean; AStart: TItrStart);
+constructor TJclLinkedListIterator<T>.Create(AOwnList: TJclLinkedList<T>; ACursor: TJclLinkedList<T>.TLinkedListItem; AValid: Boolean; AStart: TItrStart);
 begin
   inherited Create(AValid);
   FCursor := ACursor;

--- a/jcl/source/prototypes/JclLinkedLists.pas
+++ b/jcl/source/prototypes/JclLinkedLists.pas
@@ -77,7 +77,7 @@ protected
     TLinkedListItem = TJclLinkedListItem<T>;
     TLinkedListIterator = TJclLinkedListIterator<T>;,,; AOwnsItems: Boolean,const ,AItem,T,GetItem,SetItem)*)
 
-  (*$JPPEXPANDMACRO JCLLINKEDLISTITRINT(TJclLinkedListIterator<T>,IJclIterator<T>,IJclList<T>,IJclEqualityComparer<T>,TJclLinkedList<T>.TLinkedListItem,const ,AItem,T,Default(T),GetItem,SetItem)*)
+  (*$JPPEXPANDMACRO JCLLINKEDLISTITRINT(TJclLinkedListIterator<T>,IJclIterator<T>,TJclLinkedList<T>,IJclEqualityComparer<T>,TJclLinkedList<T>.TLinkedListItem,const ,AItem,T,Default(T),GetItem,SetItem)*)
 
   // E = External helper to compare items
   // GetHashCode is never called
@@ -168,7 +168,7 @@ uses
 
 {$JPPEXPANDMACRO JCLLINKEDLISTIMP(TJclLinkedList<T>,TLinkedListItem,IJclCollection<T>,IJclList<T>,IJclIterator<T>,TLinkedListIterator,; AOwnsItems: Boolean,AOwnsItems,const ,AItem,T,Default(T),GetItem,SetItem,FreeItem)}
 
-(*$JPPEXPANDMACRO JCLLINKEDLISTITRIMP(TJclLinkedListIterator<T>,IJclIterator<T>,IJclList<T>,IJclEqualityComparer<T>,TJclLinkedList<T>.TLinkedListItem,const ,AItem,T,Default(T),GetItem,SetItem,(FownList as IJclItemOwner<T>).FreeItem(FCursor.Value);)*)
+(*$JPPEXPANDMACRO JCLLINKEDLISTITRIMP(TJclLinkedListIterator<T>,IJclIterator<T>,TJclLinkedList<T>,IJclEqualityComparer<T>,TJclLinkedList<T>.TLinkedListItem,const ,AItem,T,Default(T),GetItem,SetItem,(FownList as IJclItemOwner<T>).FreeItem(FCursor.Value);)*)
 
 //=== { TJclLinkedListE<T> } =================================================
 


### PR DESCRIPTION
Ensure the linked list (TJclLinkedList<T>) iterator does not inadvertently free the parent linked list if the parent linked list is only referenced through an object reference instead of an interface reference.