### PR TITLE
Fix memory corruption in the vector (TJclVector<T>) iterator.

### DIFF
--- a/jcl/source/common/JclVectors.pas
+++ b/jcl/source/common/JclVectors.pas
@@ -1163,12 +1163,12 @@ type
   private
     FCursor: Integer;
     FStart: TItrStart;
-    FOwnList: IJclList<T>;
+    FOwnList: TJclVector<T>;
   protected
     function CreateEmptyIterator: TJclAbstractIterator; override;
     procedure AssignPropertiesTo(Dest: TJclAbstractIterator); override;
   public
-    constructor Create(AOwnList: IJclList<T>; ACursor: Integer; AValid: Boolean; AStart: TItrStart);
+    constructor Create(AOwnList: TJclVector<T>; ACursor: Integer; AValid: Boolean; AStart: TItrStart);
     { IJclIterator<T> }
     function Add(const AItem: T): Boolean;
     procedure Extract;
@@ -11771,7 +11771,7 @@ end;
 
 //=== { TJclVectorIterator<T> } ===========================================================
 
-constructor TJclVectorIterator<T>.Create(AOwnList: IJclList<T>; ACursor: Integer; AValid: Boolean; AStart: TItrStart);
+constructor TJclVectorIterator<T>.Create(AOwnList: TJclVector<T>; ACursor: Integer; AValid: Boolean; AStart: TItrStart);
 begin
   inherited Create(AValid);
   FOwnList := AOwnList;

--- a/jcl/source/prototypes/JclVectors.pas
+++ b/jcl/source/prototypes/JclVectors.pas
@@ -75,7 +75,7 @@ protected
     TVectorIterator = TJclVectorIterator<T>;
   {$JPPDEFINE GENERIC}{$JPPEXPANDMACRO MOVEARRAYINT(MoveArray,TDynArray,)},,; AOwnsItems: Boolean,const ,AItem,T,TDynArray,GetItem,SetItem)*)
 
-  (*$JPPEXPANDMACRO JCLVECTORITRINT(TJclVectorIterator<T>,IJclIterator<T>,IJclList<T>,const ,AItem,T,GetItem,SetItem)*)
+  (*$JPPEXPANDMACRO JCLVECTORITRINT(TJclVectorIterator<T>,IJclIterator<T>,TJclVector<T>,const ,AItem,T,GetItem,SetItem)*)
 
   // E = External helper to compare items for equality (GetHashCode is not used)
   TJclVectorE<T> = class(TJclVector<T>, {$IFDEF THREADSAFE} IJclLockable, {$ENDIF THREADSAFE}
@@ -165,7 +165,7 @@ uses
 
 {$JPPDEFINE GENERIC}{$JPPEXPANDMACRO MOVEARRAYIMP(MoveArray,TDynArray,Default(T),TJclVector<T>.,)}
 
-(*$JPPEXPANDMACRO JCLVECTORITRIMP(TJclVectorIterator<T>,IJclIterator<T>,IJclList<T>,const ,AItem,T,GetItem,SetItem)*)
+(*$JPPEXPANDMACRO JCLVECTORITRIMP(TJclVectorIterator<T>,IJclIterator<T>,TJclVector<T>,const ,AItem,T,GetItem,SetItem)*)
 
 //=== { TJclVectorE<T> } =====================================================
 


### PR DESCRIPTION
Ensure the vector (TJclVector<T>) iterator does not inadvertently free the parent vector if the parent vector is only referenced through an object reference instead of an interface reference.