### PR TITLE
Fix a bug in the MapEquals method of the sorted map containers.

### DIFF
--- a/jcl/source/common/JclSortedMaps.pas
+++ b/jcl/source/common/JclSortedMaps.pas
@@ -3189,9 +3189,7 @@ end;
 
 function TJclIntfIntfSortedMap.MapEquals(const AMap: IJclIntfIntfMap): Boolean;
 var
-  It: IJclIntfIterator;
   Index: Integer;
-  AKey: IInterface;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -3203,16 +3201,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -3851,9 +3848,7 @@ end;
 
 function TJclAnsiStrIntfSortedMap.MapEquals(const AMap: IJclAnsiStrIntfMap): Boolean;
 var
-  It: IJclAnsiStrIterator;
   Index: Integer;
-  AKey: AnsiString;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -3865,16 +3860,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -4513,9 +4507,7 @@ end;
 
 function TJclIntfAnsiStrSortedMap.MapEquals(const AMap: IJclIntfAnsiStrMap): Boolean;
 var
-  It: IJclIntfIterator;
   Index: Integer;
-  AKey: IInterface;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -4527,16 +4519,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -5175,9 +5166,7 @@ end;
 
 function TJclAnsiStrAnsiStrSortedMap.MapEquals(const AMap: IJclAnsiStrAnsiStrMap): Boolean;
 var
-  It: IJclAnsiStrIterator;
   Index: Integer;
-  AKey: AnsiString;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -5189,16 +5178,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -5837,9 +5825,7 @@ end;
 
 function TJclWideStrIntfSortedMap.MapEquals(const AMap: IJclWideStrIntfMap): Boolean;
 var
-  It: IJclWideStrIterator;
   Index: Integer;
-  AKey: WideString;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -5851,16 +5837,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -6499,9 +6484,7 @@ end;
 
 function TJclIntfWideStrSortedMap.MapEquals(const AMap: IJclIntfWideStrMap): Boolean;
 var
-  It: IJclIntfIterator;
   Index: Integer;
-  AKey: IInterface;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -6513,16 +6496,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -7161,9 +7143,7 @@ end;
 
 function TJclWideStrWideStrSortedMap.MapEquals(const AMap: IJclWideStrWideStrMap): Boolean;
 var
-  It: IJclWideStrIterator;
   Index: Integer;
-  AKey: WideString;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -7175,16 +7155,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -7824,9 +7803,7 @@ end;
 
 function TJclUnicodeStrIntfSortedMap.MapEquals(const AMap: IJclUnicodeStrIntfMap): Boolean;
 var
-  It: IJclUnicodeStrIterator;
   Index: Integer;
-  AKey: UnicodeString;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -7838,16 +7815,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -8489,9 +8465,7 @@ end;
 
 function TJclIntfUnicodeStrSortedMap.MapEquals(const AMap: IJclIntfUnicodeStrMap): Boolean;
 var
-  It: IJclIntfIterator;
   Index: Integer;
-  AKey: IInterface;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -8503,16 +8477,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -9154,9 +9127,7 @@ end;
 
 function TJclUnicodeStrUnicodeStrSortedMap.MapEquals(const AMap: IJclUnicodeStrUnicodeStrMap): Boolean;
 var
-  It: IJclUnicodeStrIterator;
   Index: Integer;
-  AKey: UnicodeString;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -9168,16 +9139,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -9818,9 +9788,7 @@ end;
 
 function TJclSingleIntfSortedMap.MapEquals(const AMap: IJclSingleIntfMap): Boolean;
 var
-  It: IJclSingleIterator;
   Index: Integer;
-  AKey: Single;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -9832,16 +9800,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -10480,9 +10447,7 @@ end;
 
 function TJclIntfSingleSortedMap.MapEquals(const AMap: IJclIntfSingleMap): Boolean;
 var
-  It: IJclIntfIterator;
   Index: Integer;
-  AKey: IInterface;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -10494,16 +10459,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -11142,9 +11106,7 @@ end;
 
 function TJclSingleSingleSortedMap.MapEquals(const AMap: IJclSingleSingleMap): Boolean;
 var
-  It: IJclSingleIterator;
   Index: Integer;
-  AKey: Single;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -11156,16 +11118,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -11770,9 +11731,7 @@ end;
 
 function TJclDoubleIntfSortedMap.MapEquals(const AMap: IJclDoubleIntfMap): Boolean;
 var
-  It: IJclDoubleIterator;
   Index: Integer;
-  AKey: Double;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -11784,16 +11743,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -12432,9 +12390,7 @@ end;
 
 function TJclIntfDoubleSortedMap.MapEquals(const AMap: IJclIntfDoubleMap): Boolean;
 var
-  It: IJclIntfIterator;
   Index: Integer;
-  AKey: IInterface;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -12446,16 +12402,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -13094,9 +13049,7 @@ end;
 
 function TJclDoubleDoubleSortedMap.MapEquals(const AMap: IJclDoubleDoubleMap): Boolean;
 var
-  It: IJclDoubleIterator;
   Index: Integer;
-  AKey: Double;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -13108,16 +13061,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -13722,9 +13674,7 @@ end;
 
 function TJclExtendedIntfSortedMap.MapEquals(const AMap: IJclExtendedIntfMap): Boolean;
 var
-  It: IJclExtendedIterator;
   Index: Integer;
-  AKey: Extended;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -13736,16 +13686,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -14384,9 +14333,7 @@ end;
 
 function TJclIntfExtendedSortedMap.MapEquals(const AMap: IJclIntfExtendedMap): Boolean;
 var
-  It: IJclIntfIterator;
   Index: Integer;
-  AKey: IInterface;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -14398,16 +14345,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -15046,9 +14992,7 @@ end;
 
 function TJclExtendedExtendedSortedMap.MapEquals(const AMap: IJclExtendedExtendedMap): Boolean;
 var
-  It: IJclExtendedIterator;
   Index: Integer;
-  AKey: Extended;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -15060,16 +15004,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -15674,9 +15617,7 @@ end;
 
 function TJclIntegerIntfSortedMap.MapEquals(const AMap: IJclIntegerIntfMap): Boolean;
 var
-  It: IJclIntegerIterator;
   Index: Integer;
-  AKey: Integer;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -15688,16 +15629,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -16336,9 +16276,7 @@ end;
 
 function TJclIntfIntegerSortedMap.MapEquals(const AMap: IJclIntfIntegerMap): Boolean;
 var
-  It: IJclIntfIterator;
   Index: Integer;
-  AKey: IInterface;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -16350,16 +16288,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -16998,9 +16935,7 @@ end;
 
 function TJclIntegerIntegerSortedMap.MapEquals(const AMap: IJclIntegerIntegerMap): Boolean;
 var
-  It: IJclIntegerIterator;
   Index: Integer;
-  AKey: Integer;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -17012,16 +16947,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -17626,9 +17560,7 @@ end;
 
 function TJclCardinalIntfSortedMap.MapEquals(const AMap: IJclCardinalIntfMap): Boolean;
 var
-  It: IJclCardinalIterator;
   Index: Integer;
-  AKey: Cardinal;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -17640,16 +17572,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -18288,9 +18219,7 @@ end;
 
 function TJclIntfCardinalSortedMap.MapEquals(const AMap: IJclIntfCardinalMap): Boolean;
 var
-  It: IJclIntfIterator;
   Index: Integer;
-  AKey: IInterface;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -18302,16 +18231,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -18950,9 +18878,7 @@ end;
 
 function TJclCardinalCardinalSortedMap.MapEquals(const AMap: IJclCardinalCardinalMap): Boolean;
 var
-  It: IJclCardinalIterator;
   Index: Integer;
-  AKey: Cardinal;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -18964,16 +18890,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -19578,9 +19503,7 @@ end;
 
 function TJclInt64IntfSortedMap.MapEquals(const AMap: IJclInt64IntfMap): Boolean;
 var
-  It: IJclInt64Iterator;
   Index: Integer;
-  AKey: Int64;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -19592,16 +19515,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -20240,9 +20162,7 @@ end;
 
 function TJclIntfInt64SortedMap.MapEquals(const AMap: IJclIntfInt64Map): Boolean;
 var
-  It: IJclIntfIterator;
   Index: Integer;
-  AKey: IInterface;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -20254,16 +20174,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -20902,9 +20821,7 @@ end;
 
 function TJclInt64Int64SortedMap.MapEquals(const AMap: IJclInt64Int64Map): Boolean;
 var
-  It: IJclInt64Iterator;
   Index: Integer;
-  AKey: Int64;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -20916,16 +20833,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -21530,9 +21446,7 @@ end;
 
 function TJclPtrIntfSortedMap.MapEquals(const AMap: IJclPtrIntfMap): Boolean;
 var
-  It: IJclPtrIterator;
   Index: Integer;
-  AKey: Pointer;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -21544,16 +21458,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -22192,9 +22105,7 @@ end;
 
 function TJclIntfPtrSortedMap.MapEquals(const AMap: IJclIntfPtrMap): Boolean;
 var
-  It: IJclIntfIterator;
   Index: Integer;
-  AKey: IInterface;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -22206,16 +22117,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -22854,9 +22764,7 @@ end;
 
 function TJclPtrPtrSortedMap.MapEquals(const AMap: IJclPtrPtrMap): Boolean;
 var
-  It: IJclPtrIterator;
   Index: Integer;
-  AKey: Pointer;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -22868,16 +22776,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -23483,9 +23390,7 @@ end;
 
 function TJclIntfSortedMap.MapEquals(const AMap: IJclIntfMap): Boolean;
 var
-  It: IJclIntfIterator;
   Index: Integer;
-  AKey: IInterface;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -23497,16 +23402,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -24159,9 +24063,7 @@ end;
 
 function TJclAnsiStrSortedMap.MapEquals(const AMap: IJclAnsiStrMap): Boolean;
 var
-  It: IJclAnsiStrIterator;
   Index: Integer;
-  AKey: AnsiString;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -24173,16 +24075,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -24835,9 +24736,7 @@ end;
 
 function TJclWideStrSortedMap.MapEquals(const AMap: IJclWideStrMap): Boolean;
 var
-  It: IJclWideStrIterator;
   Index: Integer;
-  AKey: WideString;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -24849,16 +24748,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -25512,9 +25410,7 @@ end;
 
 function TJclUnicodeStrSortedMap.MapEquals(const AMap: IJclUnicodeStrMap): Boolean;
 var
-  It: IJclUnicodeStrIterator;
   Index: Integer;
-  AKey: UnicodeString;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -25526,16 +25422,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -26190,9 +26085,7 @@ end;
 
 function TJclSingleSortedMap.MapEquals(const AMap: IJclSingleMap): Boolean;
 var
-  It: IJclSingleIterator;
   Index: Integer;
-  AKey: Single;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -26204,16 +26097,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -26832,9 +26724,7 @@ end;
 
 function TJclDoubleSortedMap.MapEquals(const AMap: IJclDoubleMap): Boolean;
 var
-  It: IJclDoubleIterator;
   Index: Integer;
-  AKey: Double;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -26846,16 +26736,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -27474,9 +27363,7 @@ end;
 
 function TJclExtendedSortedMap.MapEquals(const AMap: IJclExtendedMap): Boolean;
 var
-  It: IJclExtendedIterator;
   Index: Integer;
-  AKey: Extended;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -27488,16 +27375,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -28116,9 +28002,7 @@ end;
 
 function TJclIntegerSortedMap.MapEquals(const AMap: IJclIntegerMap): Boolean;
 var
-  It: IJclIntegerIterator;
   Index: Integer;
-  AKey: Integer;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -28130,16 +28014,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -28758,9 +28641,7 @@ end;
 
 function TJclCardinalSortedMap.MapEquals(const AMap: IJclCardinalMap): Boolean;
 var
-  It: IJclCardinalIterator;
   Index: Integer;
-  AKey: Cardinal;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -28772,16 +28653,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -29400,9 +29280,7 @@ end;
 
 function TJclInt64SortedMap.MapEquals(const AMap: IJclInt64Map): Boolean;
 var
-  It: IJclInt64Iterator;
   Index: Integer;
-  AKey: Int64;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -29414,16 +29292,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -30042,9 +29919,7 @@ end;
 
 function TJclPtrSortedMap.MapEquals(const AMap: IJclPtrMap): Boolean;
 var
-  It: IJclPtrIterator;
   Index: Integer;
-  AKey: Pointer;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -30056,16 +29931,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -30685,9 +30559,7 @@ end;
 
 function TJclSortedMap.MapEquals(const AMap: IJclMap): Boolean;
 var
-  It: IJclIterator;
   Index: Integer;
-  AKey: TObject;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -30699,16 +30571,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}
@@ -31347,9 +31218,7 @@ end;
 
 function TJclSortedMap<TKey,TValue>.MapEquals(const AMap: IJclMap<TKey,TValue>): Boolean;
 var
-  It: IJclIterator<TKey>;
   Index: Integer;
-  AKey: TKey;
 begin
   {$IFDEF THREADSAFE}
   if FThreadSafe then
@@ -31361,16 +31230,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$IFDEF THREADSAFE}

--- a/jcl/source/prototypes/containers/JclSortedMaps.imp
+++ b/jcl/source/prototypes/containers/JclSortedMaps.imp
@@ -222,9 +222,7 @@ end;
 
 function SELFCLASSNAME.MapEquals(const AMap: STDMAPINTERFACENAME): Boolean;
 var
-  It: KEYITRINTERFACENAME;
   Index: Integer;
-  AKey: KEYTYPENAME;
 begin
   {$JPPUNDEF WRITE}{$JPPEXPANDMACRO LOCK}
     Result := False;
@@ -232,16 +230,15 @@ begin
       Exit;
     if FSize <> AMap.Size then
       Exit;
-    It := AMap.KeySet.First;
-    Index := 0;
-    while It.HasNext do
+    for Index := 0 to FSize - 1 do
     begin
-      if Index >= FSize then
+      if AMap.ContainsKey(FEntries[Index].Key) then
+      begin
+        if ValuesCompare(AMap.GetValue(FEntries[Index].Key), FEntries[Index].Value) <> 0 then
+          Exit;
+      end
+      else
         Exit;
-      AKey := It.Next;
-      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
-        Exit;
-      Inc(Index);
     end;
     Result := True;
   {$JPPEXPANDMACRO UNLOCK}


### PR DESCRIPTION
Fix a bug in the MapEquals method of the sorted map containers to ensures both values and keys are actually compared.

The current code fails if two sorted maps are compared that have the AllowDefaultElements and ReturnDefaultElements properties set, contain the same number of elements and contain key value pairs for which the key differs and the value is the same as the 'default value' (nil, '', etc...).

For example: a TJclStrStrSortedMap map1 containing key1='' and a TJclStrStrSortedMap map2 containing key2='' will be considered equal by the current implementation of MapEquals.
This is due to the fact that map2.GetValue('key1') will return the default value ''.

The MapEquals code line that causes the problem is:
      if ValuesCompare(AMap.GetValue(AKey), FEntries[Index].Value) <> 0 then
