### PR TITLE
Fix the compiler search path of devtools (jpp, jppContainers and jppExceptionDialogs).

### DIFF
--- a/jcl/devtools/jpp/jpp.dof
+++ b/jcl/devtools/jpp/jpp.dof
@@ -1,4 +1,4 @@
 [Directories]
 OutputDir=..
 UsePackages=0
-SearchPath=..\..\source\include
+SearchPath=..\..\source\include;..\..\source\common;..\..\source\windows

--- a/jcl/devtools/jpp/jppContainers.dof
+++ b/jcl/devtools/jpp/jppContainers.dof
@@ -1,4 +1,4 @@
 [Directories]
 OutputDir=..
 UsePackages=0
-SearchPath=..\..\source\include
+SearchPath=..\..\source\include;..\..\source\common;..\..\source\windows

--- a/jcl/devtools/jpp/jppExceptionDialogs.dof
+++ b/jcl/devtools/jpp/jppExceptionDialogs.dof
@@ -1,4 +1,4 @@
 [Directories]
 OutputDir=..
 UsePackages=0
-SearchPath=..\..\source\include
+SearchPath=..\..\source\include;..\..\source\common;..\..\source\windows


### PR DESCRIPTION
Fix the compiler search path to ensure the compiler uses the source code from the current source tree.

Currently the compiler search path for jpp, jppContainers and jppExceptionDialogs only specifies the include directory from the same source tree as '..\..\source\include'. This means that the source code files the compiler needs to compile these projects that are not in that include directory will, if available, be fetched from somewhere else; typically another JCL installation as specified by the registry.

This pull request add the common and windows source directory of the same source tree (..\..\source\common;..\..\source\windows) to the compiler search path.