### PR TITLE
Fix WindowToModuleFileName wrong test

### DIFF
--- a/jcl/source/common/JclFileUtils.pas
+++ b/jcl/source/common/JclFileUtils.pas
@@ -4862,7 +4862,7 @@ begin
         if JclCheckWinVersion(6, 0) then // WinVista or newer
         begin
           DllHinst := LoadLibrary('Kernel32.dll');
-          if DllHinst < HINSTANCE_ERROR then
+          if DllHinst > HINSTANCE_ERROR then
           begin
             try
               {$IFDEF SUPPORTS_UNICODE}
@@ -4890,7 +4890,7 @@ begin
         else
         begin
           DllHinst := LoadLibrary('Psapi.dll');
-          if DllHinst < HINSTANCE_ERROR then
+          if DllHinst > HINSTANCE_ERROR then
           begin
             try
               {$IFDEF SUPPORTS_UNICODE}


### PR DESCRIPTION
There's a wrong test in WindowToModuleFileName function. If `DllHinst < HINSTANCE_ERROR` the function should fail, not the contrary. Actually, it's enough that `DllHinst` is different from 0 to be usable (`HINSTANCE_ERROR` is out of context here since it's relative to old 16-bit OS).