### PR TITLE
Wrong line numbers on CPU64

### DIFF
--- a/jcl/source/windows/JclDebug.pas
+++ b/jcl/source/windows/JclDebug.pas
@@ -5449,7 +5449,7 @@ begin
   ResetMemory(StackInfo, SizeOf(StackInfo));
   for I := 0 to CapturedFramesCount - 1 do
   begin
-    StackInfo.CallerAddr := TJclAddr(BackTrace[I]);
+    StackInfo.CallerAddr := TJclAddr(BackTrace[I]) - 2; //magic number
     StackInfo.Level := I;
     StoreToList(StackInfo); // skips all frames with a level less than "IgnoreLevels"
   end;


### PR DESCRIPTION
I did few tests on small projects and quite big ones including reccursion and noticed, that line numbers're calculated with offset = 2. And it seems to me, that this is a constant value. And tests prove that. Actually I don't have enough experience to find better solution, but I suppose, you do. This error could lead into more complicated errors, because .CallerAddr is used widely. I'dont think, that mistake is located inside CaptureStackBackTrace(internal RtlCaptureStackBackTrace). It's also could be an Embarcadero bug dcc64 but, as far as I know, it's written completely from zero.