### PR TITLE
Fix random compile error

### DIFF
--- a/jcl/source/common/JclBase.pas
+++ b/jcl/source/common/JclBase.pas
@@ -113,7 +113,7 @@ type
   UInt64 = Int64;
   {$ENDIF ~COMPILER7_UP}
   PWideChar = System.PWideChar;
-  PPWideChar = ^JclBase.PWideChar;
+  PPWideChar = ^PWideChar;
   PPAnsiChar = ^PAnsiChar;
   PInt64 = type System.PInt64;
   {$ENDIF ~FPC}


### PR DESCRIPTION
This line caused random compile errors, expecting ; but got . 
Removing the reference to JclBase seems to solve the error below:
```
Jedi-jcl\source\common\JclBase.pas(116Error: E2029 ';' expected but '.' found
Jedi-jcl\source\common\JclBase.pas(310Fatal: F2063 Could not compile used unit 'JclResources.pas'
```
i've only gotten this error when removing my DCU'S. 