### PR TITLE
Compilation of jcl_a2z.cpp and jcl_z2a.cpp fails on 10.3 / 64 bit

### DIFF
--- a/jcl/install/JclInstall.pas
+++ b/jcl/install/JclInstall.pas
@@ -1711,7 +1711,10 @@ var
           Target.BCC.Options.Add('-fno-spell-checking');
           Target.BCC.Options.Add('-fno-use-cxa-atexit');
           Target.BCC.Options.Add('-x c++');
-          Target.BCC.Options.Add('-std=c++11');
+          if Target.IDEVersionNumber >= 20 then
+            Target.BCC.Options.Add('-std=c++17')
+          else
+            Target.BCC.Options.Add('-std=c++11');
           Target.BCC.Options.Add('-O0');
           Target.BCC.Options.Add('-tC');
           Target.BCC.Options.Add('-tM');


### PR DESCRIPTION
C++ Builder 10.3 supports C++17 standard. During .hpp files check, the 64 bit C++ compiler is passed the option "-std=c++11", which causes the compilation to fail due to some constructs in the dinkumware64 standard library that are C++17 specific.
Checking for IDE version and passing "-std=c++17" if it's >= 20.