### PR TITLE
Added IFDEFs to make JCL compatible with FPC 64-bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,13 @@ __history
 # 64bit Delphi/C++Builder files
 *.[ao]
 
+# FreePascal Compiler output files
+*.a
+*.compiled
+*.o
+*.ppu
+*.rsj
+
 # Lib directories
 jcl/lib/*/*.res
 jcl/lib/*/debug/*.res

--- a/jcl/packages/fpc/Jcl.lpk
+++ b/jcl/packages/fpc/Jcl.lpk
@@ -1,17 +1,16 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CONFIG>
-  <Package Version="3">
+  <Package Version="4">
     <PathDelim Value="\"/>
     <Name Value="Jcl"/>
-    <AddToProjectUsesSection Value="False"/>
     <Author Value="Project JEDI"/>
     <AutoUpdate Value="OnRebuildingAll"/>
     <CompilerOptions>
-      <Version Value="9"/>
+      <Version Value="11"/>
       <PathDelim Value="\"/>
       <SearchPaths>
-        <IncludeFiles Value="..\..\source\include\"/>
-        <OtherUnitFiles Value=".;..\..\source\common;..\..\source\windows;;..\..\lib\fpc\$(TargetCPU)-$(TargetOS)"/>
+        <IncludeFiles Value="..\..\source\include"/>
+        <OtherUnitFiles Value="..\..\source\common;..\..\source\windows;..\..\lib\fpc\$(TargetCPU)-$(TargetOS)"/>
         <UnitOutputDirectory Value="..\..\lib\fpc\$(TargetCPU)-$(TargetOS)"/>
       </SearchPaths>
       <Parsing>
@@ -24,22 +23,14 @@
       </Parsing>
       <CodeGeneration>
         <Optimizations>
-          <VariablesInRegisters Value="True"/>
           <OptimizationLevel Value="3"/>
+          <VariablesInRegisters Value="True"/>
         </Optimizations>
       </CodeGeneration>
-      <Linking>
-        <Debugging>
-          <UseLineInfoUnit Value="False"/>
-        </Debugging>
-      </Linking>
-      <Other>
-        <CompilerPath Value="$(CompPath)"/>
-      </Other>
     </CompilerOptions>
     <Description Value="JEDI Code Library RTL package"/>
     <License Value="Copyright (C) 1999, 2014 Project JEDI"/>
-    <Version Major="2" Minor="7" Release="0" Build="5300"/>
+    <Version Major="2" Minor="7" Build="5300"/>
     <Files Count="74">
       <Item1>
         <Filename Value="..\..\source\common\bzip2.pas"/>
@@ -344,14 +335,13 @@
       </Item1>
     </RequiredPkgs>
     <UsageOptions>
-      <IncludePath Value="..\..\source\include\"/>
-      <LibraryPath Value="$(PkgOutDir)\"/>
-      <ObjectPath Value="..\..\lib\fpc\$(TargetCPU)-$(TargetOS)\"/>
-      <UnitPath Value="$(PkgOutDir)\"/>
+      <IncludePath Value="..\..\source\include"/>
+      <LibraryPath Value="$(PkgOutDir)"/>
+      <ObjectPath Value="..\..\lib\fpc\$(TargetCPU)-$(TargetOS)"/>
+      <UnitPath Value="$(PkgOutDir)"/>
     </UsageOptions>
     <PublishOptions>
       <Version Value="2"/>
-      <IgnoreBinaries Value="False"/>
     </PublishOptions>
   </Package>
 </CONFIG>

--- a/jcl/source/common/JclAnsiStrings.pas
+++ b/jcl/source/common/JclAnsiStrings.pas
@@ -4141,12 +4141,12 @@ begin
   end;
 end;
 
-function AnsiCompareNaturalStr(const S1, S2: AnsiString): SizeInt; overload;
+function AnsiCompareNaturalStr(const S1, S2: AnsiString): SizeInt;{$IFDEF DELPHICOMPILER}overload;{$ENDIF}
 begin
   Result := AnsiCompareNatural(S1, S2, False);
 end;
 
-function AnsiCompareNaturalText(const S1, S2: AnsiString): SizeInt; overload;
+function AnsiCompareNaturalText(const S1, S2: AnsiString): SizeInt;{$IFDEF DELPHICOMPILER}overload;{$ENDIF}
 begin
   Result := AnsiCompareNatural(S1, S2, True);
 end;

--- a/jcl/source/common/JclDateTime.pas
+++ b/jcl/source/common/JclDateTime.pas
@@ -263,7 +263,7 @@ const
   //   7 : first full week
   //ISOFirstWeekMinDays = 4;
 
-function EncodeDate(const Year: Integer; Month, Day: Word): TDateTime; overload;
+function EncodeDate(const Year: Integer; Month, Day: Word): TDateTime;{$IFDEF DELPHICOMPILER}overload;{$ENDIF}
 begin
   if (Year > 0) and (Year < EncodeDateMaxYear + 1) then
     Result := {$IFDEF HAS_UNITSCOPE}System.{$ENDIF}SysUtils.EncodeDate(Year, Month, Day)

--- a/jcl/source/common/JclRTTI.pas
+++ b/jcl/source/common/JclRTTI.pas
@@ -2223,12 +2223,12 @@ begin
   if TypeData.elType = nil then
   begin
     if TypeData.elType2 <> nil then
-      Result := JclTypeInfo(TypeData.elType2^)
+      Result := JclTypeInfo(TypeData.elType2{$IFDEF DELPHICOMPILER}^{$ENDIF})
     else
       Result := nil;
   end
   else
-    Result := JclTypeInfo(TypeData.elType^);
+    Result := JclTypeInfo(TypeData.elType{$IFDEF DELPHICOMPILER}^{$ENDIF});
 end;
 
 function TJclDynArrayTypeInfo.GetElementsNeedCleanup: Boolean;

--- a/jcl/source/common/JclSimpleXml.pas
+++ b/jcl/source/common/JclSimpleXml.pas
@@ -629,7 +629,7 @@ type
       const Name: string; const Arguments: TVarDataArray): Boolean; override;
     function GetProperty(var Dest: TVarData; const V: TVarData;
       const Name: string): Boolean; override;
-    function SetProperty(const V: TVarData; const Name: string;
+    function SetProperty(var V: TVarData; const Name: string;
       const Value: TVarData): Boolean; override;
   end;
 
@@ -4244,7 +4244,7 @@ begin
   Result := (VXML = nil) or (not VXML.HasItems);
 end;
 
-function TXMLVariant.SetProperty(const V: TVarData; const Name: string;
+function TXMLVariant.SetProperty(var V: TVarData; const Name: string;
   const Value: TVarData): Boolean;
 
   function GetStrValue: string;

--- a/jcl/source/common/JclStrings.pas
+++ b/jcl/source/common/JclStrings.pas
@@ -5390,12 +5390,12 @@ begin
   end;
 end;
 
-function CompareNaturalStr(const S1, S2: string): SizeInt; overload;
+function CompareNaturalStr(const S1, S2: string): SizeInt;{$IFDEF DELPHICOMPILER}overload;{$ENDIF}
 begin
   Result := CompareNatural(S1, S2, False);
 end;
 
-function CompareNaturalText(const S1, S2: string): SizeInt; overload;
+function CompareNaturalText(const S1, S2: string): SizeInt;{$IFDEF DELPHICOMPILER}overload;{$ENDIF}
 begin
   Result := CompareNatural(S1, S2, True);
 end;

--- a/jcl/source/common/JclSysInfo.pas
+++ b/jcl/source/common/JclSysInfo.pas
@@ -3167,7 +3167,7 @@ end;
 
 function IsWindowResponding(Wnd: THandle; Timeout: Integer): Boolean;
 var
-  Res: DWORD;
+  Res: DWORD_PTR;
 begin
   Res := 0;
   Result := SendMessageTimeout(Wnd, WM_NULL, 0, 0, SMTO_ABORTIFHUNG, Timeout, {$IFDEF RTL230_UP}@{$ENDIF}Res) <> 0;
@@ -4191,8 +4191,6 @@ begin
           Result := 'Windows 10 October 2018 Update';
        1903:
           Result := 'Windows 10 May 2019 Update';
-       1909:
-          Result := 'Windows 10 November 2019 Update';
        2004:
           Result := 'Windows 10 May 2020 Update';
      else
@@ -4224,8 +4222,6 @@ begin
           Result := 'Redstone 5';
        1903:
           Result := '19H1';
-       1909:
-          Result := '19H2';
        2004:
           Result := '20H1';
     else

--- a/jcl/source/windows/JclCOM.pas
+++ b/jcl/source/windows/JclCOM.pas
@@ -486,7 +486,7 @@ end;
 
 function ResetIStreamToStart(Stream: IStream): Boolean;
 var
-  i64Pos: {$IFDEF RTL290_UP}LargeUInt{$ELSE}Largeint{$ENDIF RTL290_UP};
+  i64Pos: {$IF DEFINED(RTL290_UP) OR DEFINED(CPU64)}LargeUInt{$ELSE}Largeint{$ENDIF RTL290_UP};
   hrSeek: HRESULT;
 begin
   { TODO -cTest : D4 (CBx ??) }

--- a/jcl/source/windows/JclRegistry.pas
+++ b/jcl/source/windows/JclRegistry.pas
@@ -62,7 +62,11 @@ uses
   JclBase, JclStrings;
 
 type
-  DelphiHKEY = {$IFDEF CPUX64}type Winapi.Windows.HKEY{$ELSE}Longword{$ENDIF CPUX64};
+  {$IFDEF CPU64}
+  DelphiHKEY = type {$IFDEF HAS_UNITSCOPE}Winapi.{$ENDIF}Windows.HKEY;
+  {$ELSE ~CPU64}
+  DelphiHKEY = type Longword;
+  {$ENDIF ~CPU64}
   {$HPPEMIT '// BCB users must typecast the HKEY values to DelphiHKEY or use the HK-values below.'}
 
   TExecKind = (ekMachineRun, ekMachineRunOnce, ekUserRun, ekUserRunOnce,
@@ -398,7 +402,7 @@ uses
   Winapi.AccCtrl,
   {$ELSE ~HAS_UNITSCOPE}
   SysUtils,
-  AccCtrl,
+  {$IFDEF DELPHILANGUAGE}AccCtrl,{$ENDIF ~DELPHILANGUAGE}
   {$ENDIF ~HAS_UNITSCOPE}
   {$IFDEF FPC}
 //  JwaAccCtrl,

--- a/jcl/source/windows/JclStructStorage.pas
+++ b/jcl/source/windows/JclStructStorage.pas
@@ -730,7 +730,7 @@ end;
 function TJclStructStorageStream.CopyTo(Stream: TJclStructStorageStream;
   Size: Int64): Boolean;
 var
-  DidRead, DidWrite: {$IFDEF RTL290_UP}LargeUInt{$ELSE}Largeint{$ENDIF RTL290_UP};
+  DidRead, DidWrite: {$IF DEFINED(RTL290_UP) OR DEFINED(CPU64)}LargeUInt{$ELSE}Largeint{$ENDIF RTL290_UP};
 begin
   DidRead := 0;
   DidWrite := 0;
@@ -774,7 +774,7 @@ end;
 
 function TJclStructStorageStream.Seek(Offset: Integer; Origin: Word): Longint;
 var
-  N: {$IFDEF RTL290_UP}LargeUInt{$ELSE}Largeint{$ENDIF RTL290_UP};
+  N: {$IF DEFINED(RTL290_UP) OR DEFINED(CPU64)}LargeUInt{$ELSE}Largeint{$ENDIF RTL290_UP};
 begin
   Check;
   if not Succeeded(FStream.Seek(Offset, Ord(Origin), N)) then

--- a/jcl/source/windows/JclWin32.pas
+++ b/jcl/source/windows/JclWin32.pas
@@ -55,7 +55,11 @@ unit JclWin32;
 {$I windowsonly.inc}
 
 {$MINENUMSIZE 4}
-{$ALIGN ON}
+{$IFDEF WIN64}
+  {$ALIGN 8}
+{$ELSE}
+  {$ALIGN 4}
+{$ENDIF}
 
 interface
 


### PR DESCRIPTION
Here is a set of small modifications mostly related to conditional compilation in order to make the JCL package compilable by the FPC 64-bit compiler.
