### PR TITLE
Malformed FixedProcedureName inside Callstack

### DIFF
--- a/jcl/source/windows/JclDebug.pas
+++ b/jcl/source/windows/JclDebug.pas
@@ -4696,7 +4696,7 @@ begin
     begin
       UnitNameWithoutUnitscope := UnitName;
       Delete(UnitNameWithoutUnitscope, 1, Pos('.', UnitNameWithoutUnitscope));
-      if Pos(UnitNameWithoutUnitscope + '.', FixedProcedureName) = 1 then
+      if Pos(StrLower(UnitNameWithoutUnitscope) + '.', StrLower(FixedProcedureName)) = 1 then
         FixedProcedureName := Copy(FixedProcedureName, Length(UnitNameWithoutUnitscope) + 2, Length(FixedProcedureName) - Length(UnitNameWithoutUnitscope) - 1);
     end;
 


### PR DESCRIPTION
In case a Unit contains an uppercase character after the first dot (e.g. DUnitX.Test**R**unner), the "FixedProcedureName" inside GetLocationInfoStr is malformed.

TJclLocationInfo.UnitName: 'DUnitX.TestRunner'
TJclLocationInfo.ProcedureName: 'Testrunner.TDUnitXTestRunner.ExecuteTest'
Tries to remove 'TestRunner' from TJclLocationInfo.ProcedureName which results into 'Testrunner.TDUnitXTestRunner.ExecuteTest'

Current Behavior
`(000A12BB){Xyz.exe} [004A22BB] DUnitX.TestRunner.Testrunner.TDUnitXTestRunner.ExecuteTest (Line 740, "DUnitX.TestRunner.pas" + 11) + $8`
Expected Behavior
`(000A12BB){Xyz.exe} [004A22BB] DUnitX.TestRunner.TDUnitXTestRunner.ExecuteTest (Line 740, "DUnitX.TestRunner.pas" + 11) + $8`