### PR TITLE
Added Windows 11 version detection

### DIFF
--- a/jcl/source/common/JclResources.pas
+++ b/jcl/source/common/JclResources.pas
@@ -1960,6 +1960,7 @@ resourcestring
   RsOSVersionWinServer2016      = 'Windows Server 2016';
   RsOSVersionWinServer2019      = 'Windows Server 2019';
   RsOSVersionWinServer          = 'Windows Server';
+  RsOSVersionWin11              = 'Windows 11';
 
   RsEditionWinXPHome            = 'Home Edition';
   RsEditionWinXPPro             = 'Professional';

--- a/jcl/source/common/JclSysInfo.pas
+++ b/jcl/source/common/JclSysInfo.pas
@@ -321,6 +321,9 @@ const
   PROCESSOR_ARCHITECTURE_IA64 = 6;
   {$EXTERNALSYM PROCESSOR_ARCHITECTURE_IA64}
 
+const
+  Windows11InitialBuildNumber = 22000;
+
 function GetWindowsVersion: TWindowsVersion;
 function GetWindowsEdition: TWindowsEdition;
 function NtProductType: TNtProductType;
@@ -3429,7 +3432,6 @@ const
   cShellBootSection = 'boot';
 begin
   if IsWinNT then
-    { TODO: check whether we need to access the 'native' key here? }
     Result := RegReadStringDef(HKEY_LOCAL_MACHINE, cShellKey, cShellValue, '')
   else
     Result := IniReadString(PathAddSeparator(GetWindowsFolder) + cShellSystemIniFileName, cShellBootSection, cShellValue);
@@ -3637,7 +3639,7 @@ begin
               OSVersionInfoEx.dwOSVersionInfoSize := SizeOf(OSVersionInfoEx);
               if GetVersionEx(OSVersionInfoEx) and (OSVersionInfoEx.wProductType = VER_NT_WORKSTATION) then
               begin
-                if GetWindowsBuildNumber >= 22000 then
+                if GetWindowsBuildNumber >= Windows11InitialBuildNumber then
                   Result := wvWin11
                 else
                   Result := wvWin10

--- a/jcl/source/common/JclSysInfo.pas
+++ b/jcl/source/common/JclSysInfo.pas
@@ -4345,8 +4345,7 @@ begin
     else
       Result := '';
   end
-  else
-    if IsWinServer then
+  else if IsWinServer then
   begin
     WindowsReleaseId := GetWindowsReleaseId;
     if WindowsReleaseId > 0 then
@@ -4359,8 +4358,7 @@ begin
     else
       Result := '';
   end
-  else
-  if IsWin11 then // And higher versions too?
+  else if IsWin11 then // And higher versions too?
     Result := GetWindowsVersionString + ', version ' + GetWindowsDisplayVersion
   else
     Result := '';


### PR DESCRIPTION
Added Windows 11 version detection for `GetWindowsVersion` and the public variable `IsWin11`.

Kept the Windows 10 based 'editions' and `GetWindows10...` functions as Windows 11 basically is still a 'Windows 10' version:
- see newly introduced `GetWindowsProductName` method