### PR TITLE
AnsiGetNextCharFromStream to return correct result

### DIFF
--- a/jcl/source/common/JclStringConversions.pas
+++ b/jcl/source/common/JclStringConversions.pas
@@ -2646,7 +2646,7 @@ begin
   Result := StreamReadByte(S, B);
   if Result then
   begin
-    UTF16Buffer := WideString(AnsiString(Chr(B)));
+    UTF16Buffer := WideString(AnsiString(AnsiChar(B)));
     TmpPos := 1;
     Ch := UTF16GetNextChar(UTF16Buffer, TmpPos);
     Result := TmpPos <> -1;


### PR DESCRIPTION
In Unicode versions AnsiGetNextCharFromStream(Stream; out Ch) returns a different result from AnsiGetNextCharFromStream(Stream; CodePage; out Ch) when reading extended characters (i.e. ANSI 128 - 255)

If system code page is 1252 and the next byte to read is 128 then the first function returns Ch = ? and the second function returns Ch = € (when we pass in CodePage as 1252), which is the correct result for this code page.