### PR TITLE
Resolved issues 6701, 6734, 6745

### DIFF
--- a/jcl/source/common/JclResources.pas
+++ b/jcl/source/common/JclResources.pas
@@ -1959,6 +1959,7 @@ resourcestring
   RsOSVersionWin10              = 'Windows 10';
   RsOSVersionWinServer2016      = 'Windows Server 2016';
   RsOSVersionWinServer2019      = 'Windows Server 2019';
+  RsOSVersionWinServer2022      = 'Windows Server 2022';
   RsOSVersionWinServer          = 'Windows Server';
   RsOSVersionWin11              = 'Windows 11';
 

--- a/jcl/source/common/JclSysInfo.pas
+++ b/jcl/source/common/JclSysInfo.pas
@@ -257,7 +257,7 @@ type
     wvWin2003, wvWinXP64, wvWin2003R2, wvWinVista, wvWinServer2008,
     wvWin7, wvWinServer2008R2, wvWin8, wvWin8RT, wvWinServer2012,
     wvWin81, wvWin81RT, wvWinServer2012R2, wvWin10, wvWinServer2016,
-    wvWinServer2019, wvWinServer, wvWin11);
+    wvWinServer2019, wvWinServer, wvWin11, wvWinServer2022);
   TWindowsEdition =
    (weUnknown, weWinXPHome, weWinXPPro, weWinXPHomeN, weWinXPProN, weWinXPHomeK,
     weWinXPProK, weWinXPHomeKN, weWinXPProKN, weWinXPStarter, weWinXPMediaCenter,
@@ -308,6 +308,7 @@ var
   IsWin10: Boolean = False;
   IsWinServer2016: Boolean = False;
   IsWinServer2019: Boolean = False;
+  IsWinServer2022: Boolean = False;
   IsWinServer: Boolean = False;
   IsWin11: Boolean = False;
 
@@ -3588,7 +3589,7 @@ begin
                  Win32MinorVersionEx := 4 // Windows 10 (builds < 9926) and Windows Server 2016 (builds < 10074)
               else
               if Win32MajorVersionEx = 10 then
-                 Win32MinorVersionEx := -1 // Windows 10 (builds >= 9926) and Windows Server 2016/2019 (builds >= 10074), set to -1 to escape case block
+                 Win32MinorVersionEx := -1 // Windows 10 (builds >= 9926) and Windows Server 2016/2019/2022 (builds >= 10074), set to -1 to escape case block
               else
                  Win32MinorVersionEx := Win32MinorVersion;
             end;
@@ -3680,6 +3681,8 @@ begin
                     Result := wvWinServer2016;
                   1809:
                     Result := wvWinServer2019;
+                  2009:
+                    Result := wvWinServer2022;
                 else
                     Result := wvWinServer;
                 end;
@@ -4006,6 +4009,8 @@ begin
       Result := LoadResString(@RsOSVersionWinServer2016);
     wvWinServer2019:
       Result := LoadResString(@RsOSVersionWinServer2019);
+    wvWinServer2022:
+      Result := LoadResString(@RsOSVersionWinServer2022);
     wvWinServer:
       Result := LoadResString(@RsOSVersionWinServer);
     wvWin11:
@@ -6574,6 +6579,8 @@ begin
       IsWinServer2016 := True;
     wvWinServer2019:
       IsWinServer2019 := True;
+    wvWinServer2022:
+      IsWinServer2022 := True;
     wvWinServer:
       IsWinServer := True;
     wvWin11:

--- a/jcl/source/windows/JclSvcCtrl.pas
+++ b/jcl/source/windows/JclSvcCtrl.pas
@@ -1086,7 +1086,7 @@ procedure TJclSCManager.Refresh(const RefreshAll: Boolean);
       repeat
         ReallocMem(PBuf, BytesNeeded);
         ServicesReturned := 0;
-        Ret := EnumServicesStatus(FHandle, SERVICE_TYPE_ALL, SERVICE_STATE_ALL,
+        Ret := EnumServicesStatus(FHandle, SERVICE_WIN32 or SERVICE_ADAPTER or SERVICE_DRIVER or SERVICE_INTERACTIVE_PROCESS, SERVICE_STATE_ALL,
           PEnumServiceStatus(PBuf){$IFNDEF FPC}{$IFNDEF RTL340_UP}^{$ENDIF}{$ENDIF},
           BytesNeeded, BytesNeeded, ServicesReturned, ResumeHandle);
         LastError := GetLastError;
@@ -1423,7 +1423,7 @@ end;
 function GetServiceStatusByName(const AServer,AServiceName:string):TJclServiceState;
 var
   ServiceHandle,
-  SCMHandle: DWORD;
+  SCMHandle: SC_HANDLE;
   SCMAccess,Access:DWORD;
   ServiceStatus: TServiceStatus;
 begin
@@ -1452,7 +1452,7 @@ end;
 function StartServiceByName(const AServer,AServiceName: String):Boolean;
 var
   ServiceHandle,
-  SCMHandle: DWORD;
+  SCMHandle: SC_HANDLE;
   p: PChar;
 begin
   p:=nil;
@@ -1474,7 +1474,7 @@ end;
 function StopServiceByName(const AServer, AServiceName: String):Boolean;
 var
   ServiceHandle,
-  SCMHandle: DWORD;
+  SCMHandle: SC_HANDLE;
   SS: _Service_Status;
 begin
   Result := False;


### PR DESCRIPTION
https://issuetracker.delphi-jedi.org/view.php?id=6701
TJclSCManager system error 87 (parameter incorrect) in Delphi 10.4 running on older Windows version (Windows 7, Windows 2008 server.. )

https://issuetracker.delphi-jedi.org/view.php?id=6734
Windows 2022 Server detection missing

https://issuetracker.delphi-jedi.org/view.php?id=6745
Range check error calling OpenSCManager on win64 using Alexandria 11.1