### PR TITLE
fixed StrScanW: need Dec(StrLen)

### DIFF
--- a/jcl/source/common/JclWideStrings.pas
+++ b/jcl/source/common/JclWideStrings.pas
@@ -913,6 +913,7 @@ begin
     if Result^ = Chr then
       Exit;
     Inc(Result);
+    Dec(StrLen);
   end;
   Result := nil;
 end;


### PR DESCRIPTION
StrScanW has a bug: Dec(StrLen) missing