### PR TITLE
Fix pivot selection in `JclSimpleXml.QuickSort`

### DIFF
--- a/jcl/source/common/JclSimpleXml.pas
+++ b/jcl/source/common/JclSimpleXml.pas
@@ -2649,6 +2649,10 @@ begin
       if I < J then
       begin
         List.Exchange(I, J);
+        if M = I then
+          M := J
+        else if M = J then
+          M := I;
         Inc(I);
         Dec(J);
       end


### PR DESCRIPTION
I ran across a case where `TJclSimpleXMLElems.Sort` had to be called twice in order to get the correct/expected ordering.

The internal `JclSimpleXml.QuickSort` implementation has a bug in its pivot selection/management.
* The sort assumes that the pivot index (`M`) never changes.
* When elements are exchanged, the pivot may be one of the impacted elements. In this the case, `M` should be updated.

This surfaces as incorrect sorting in `TJclSimpleXMLElems.Sort` and `TJclSimpleXMLElems.CustomSort`.