### PR TITLE
Fix asm x64 implemetation for ReverseBytes functions with two-byte arguments

### DIFF
--- a/jcl/source/common/JclLogic.pas
+++ b/jcl/source/common/JclLogic.pas
@@ -1904,8 +1904,8 @@ asm
   {$IFDEF CPU64}
   // --> CX Value
   // <-- AX Value
-  MOV    CL, AH
-  MOV    CH, AL
+  MOV    AH, CL
+  MOV    AL, CH
   {$ENDIF CPU64}
 end;
 {$ENDIF ~PUREPASCAL}
@@ -1925,8 +1925,8 @@ asm
   {$IFDEF CPU64}
   // --> CX Value
   // <-- AX Value
-  MOV    CL, AH
-  MOV    CH, AL
+  MOV    AH, CL
+  MOV    AL, CH
   {$ENDIF CPU64}
 end;
 {$ENDIF ~PUREPASCAL}


### PR DESCRIPTION
mixed up places for registers A[HL] and C[HL]