### PR TITLE
Take target file name from project settings instead of guessing

### DIFF
--- a/jcl/experts/common/JclOtaResources.pas
+++ b/jcl/experts/common/JclOtaResources.pas
@@ -266,7 +266,7 @@ resourcestring
   RsEMapFileNotFound = 'Map file "%s" for project "%s" not found.' +
     'No conversions of debug information were made';
   RsConvertedMapToJdbg = 'Converted MAP file "%s" (%d bytes) to .jdbg (%d bytes)';
-  RsInsertedJdbg = 'Converted MAP file "%s" (%d bytes) and inserted debug information (%d bytes) into the binary';
+  RsInsertedJdbg = 'Converted MAP file "%s" (%d bytes) and inserted debug information (%d bytes) into the binary "%s"';
   RsDeletedMapFile = 'Deleted %s file "%s"';
   RsEFailedToDeleteMapFile = 'Failed to delete %s file "%s"';
   RsEMapConversion = 'Failed to convert MAP file "%s"';

--- a/jcl/experts/common/JclOtaUtils.pas
+++ b/jcl/experts/common/JclOtaUtils.pas
@@ -202,6 +202,7 @@ type
       var ExecutableFileName: TFileName): Boolean;
     function GetDrcFileName(const Project: IOTAProject): TFileName;
     function GetMapFileName(const Project: IOTAProject): TFileName;
+    function GetTargetFileName(const Project: IOTAProject): TFileName;
     function GetOutputDirectory(const Project: IOTAProject): string;
     function IsInstalledPackage(const Project: IOTAProject): Boolean;
     function IsPackage(const Project: IOTAProject): Boolean;
@@ -1175,6 +1176,19 @@ begin
     raise EJclExpertException.CreateRes(@RsENoActiveProject);
 
   Result := ChangeFileExt(Project.FileName, CompilerExtensionDRC);
+end;
+
+function TJclOTAExpertBase.GetTargetFileName(const Project: IOTAProject): TFileName;
+begin
+  if not Assigned(Project) then
+    raise EJclExpertException.CreateRes(@RsENoActiveProject);
+  if not Assigned(Project.ProjectOptions) then
+    raise EJclExpertException.CreateRes(@RsENoProjectOptions);
+{$IFDEF BDS2_UP}
+  Result := Project.ProjectOptions.TargetName;
+{$ELSE ~BDS2_UP}
+  Result := '';
+{$ENDIF ~BDS2_UP}
 end;
 
 function TJclOTAExpertBase.GetMapFileName(const Project: IOTAProject): TFileName;

--- a/jcl/experts/debug/converter/JclDebugIdeImpl.pas
+++ b/jcl/experts/debug/converter/JclDebugIdeImpl.pas
@@ -360,7 +360,10 @@ begin
         // insertion of JEDI Debug Information into the binary
         if Succ and (deInsertJdbg in EnabledActions) then
         begin
-          Succ := FindExecutableName(MapFileName, OutputDirectory, ExecutableFileName);
+          ExecutableFileName := GetTargetFileName(Project);
+          Succ := ExecutableFileName <> '';
+          if not Succ then
+            Succ := FindExecutableName(MapFileName, OutputDirectory, ExecutableFileName);
           if Succ then
           begin
             Succ := InsertDebugDataIntoExecutableFile(ExecutableFileName, MapFileName,
@@ -368,7 +371,8 @@ begin
             if Succ then
             begin
               if not FQuiet then
-                OutputToolMessage(Format(LoadResString(@RsInsertedJdbg), [MapFileName, MapFileSize, JclDebugDataSize]));
+                OutputToolMessage(Format(LoadResString(@RsInsertedJdbg),
+                  [MapFileName, MapFileSize, JclDebugDataSize, ExecutableFileName]));
             end
             else
               OutputToolMessage(Format(LoadResString(@RsEMapInsertion), [MapFileName]));


### PR DESCRIPTION
When using [Better Translation Manager](https://bitbucket.org/anders_melander/better-translation-manager), PE executables with translations will be created next to target exe file. Depending on their language and extension they may be found faster than exe itself by function FindExecutableName. Usage of this function is unreliable and not required since we have target executable name available in project settings in Delphi 8 and newer. Delphi 7 will have old logic, but it will be easier to find problem because of better logging.