### PR TITLE
JclIDEUtils: Add `IDEUpdateNumber` property to get RAD Studio update info

### DIFF
--- a/jcl/source/common/JclIDEUtils.pas
+++ b/jcl/source/common/JclIDEUtils.pas
@@ -450,6 +450,7 @@ type
     function GetEnvironmentVariables: TStrings; virtual;
     function GetVclIncludeDir(APlatform: TJclBDSPlatform): string; virtual;
     function GetName: string; virtual;
+    function GetIDEUpdateNumber: Integer;
     procedure OutputString(const AText: string);
     function OutputFileDelete(const FileName: string): Boolean;
     procedure SetOutputCallback(const Value: TTextHandler); virtual;
@@ -582,6 +583,7 @@ type
     property ConfigDataLocation: string read FConfigDataLocation;
     property Globals: TStrings read GetGlobals;
     property Name: string read GetName;
+    property IDEUpdateNumber: Integer read GetIDEUpdateNumber;
     property Palette: TJclBorRADToolPalette read GetPalette;
     property Repository: TJclBorRADToolRepository read GetRepository;
     property RootDir: string read FRootDir;
@@ -2631,6 +2633,14 @@ end;
 function TJclBorRADToolInstallation.GetName: string;
 begin
   Result := Format('%s %d', [RADToolName, IDEVersionNumber]);
+end;
+
+function TJclBorRADToolInstallation.GetIDEUpdateNumber: Integer;
+var
+  MainProductUpdate: string;
+begin
+  MainProductUpdate := ConfigData.ReadString('InstalledUpdates', 'Main Product Update', '');
+  Result := StrToIntDef(StrAfter('Update', MainProductUpdate), 0);
 end;
 
 function TJclBorRADToolInstallation.GetObjFolderName(APlatform: TJclBDSPlatform): string;


### PR DESCRIPTION
There is currently no way to check if the current IDE version is RAD Studio 13.1 or later.
After this PR is merged, the following approach will be available: `IDEVersionNumber >= 37 and IDEUpdateNumber >= 1`.

The implementation reads the `InstalledUpdates\Main Product Update` registry key. This information is also displayed in the IDE's About dialog. I checked the registry and this appears to be the only way to retrieve it.

<img width="1362" height="346" alt="image" src="https://github.com/user-attachments/assets/1ca1aba8-21c7-47ee-9aff-ed4ef2e0708c" />

<img width="1039" height="794" alt="image" src="https://github.com/user-attachments/assets/f4d6ed8f-9272-4e6f-b7f2-14d68b4d8e81" />
