### PR TITLE
Fix incorrect conditional compilation COMPILER37_UP

### DIFF
--- a/jcl/source/windows/JclCppException.pas
+++ b/jcl/source/windows/JclCppException.pas
@@ -315,16 +315,12 @@ function CppGetBase(var Obj: Pointer; TypeDesc: PCppTypeId;
 function EJclCppException.AsCppClass<TCppClass>: TPointerType<TCppClass>.TPointer;
 begin
   Assert(False);
-  {$IFDEF COMPILER37_UP}
   Result := nil;
-  {$ENDIF COMPILER37_UP}
 end;
 function EJclCppException.IsCppClass<TCppClass>: Boolean;
 begin
   Assert(False);
-  {$IFDEF COMPILER37_UP}
   Result := False;
-  {$ENDIF COMPILER37_UP}
 end;
 {$ENDIF ~WIN64}
 {$ENDIF COMPILER15_UP}


### PR DESCRIPTION
The warning 'W1035 Return value of function 'xxx' might be undefined' was changed in Delphi 12, not Delphi 13. Removing the conditional compilation applies to all cases.

Previous commit: c5e9904b88d09d7fb3d0c3d65801c65d26ae8f12
Delphi 12 what's new: https://docwiki.embarcadero.com/RADStudio/Athens/en/What's_New#Improved_Warnings_in_Generic_classes