### PR TITLE
JclIDEUtils: Add `SupportsLSIF` property to detect whether the IDE supports LSIF

### DIFF
--- a/jcl/source/common/JclIDEUtils.pas
+++ b/jcl/source/common/JclIDEUtils.pas
@@ -475,6 +475,7 @@ type
     function GetCompilerSettingsFormat: TJclCompilerSettingsFormat;
     function GetSupportsNoConfig: Boolean;
     function GetSupportsPlatform: Boolean;
+    function GetSupportsLSIF: Boolean;
 
     procedure CheckPlatform(APlatform: TJclBDSPlatform);
     procedure CheckCBuilderPlatform(APlatform: TJclBDSPlatform);
@@ -608,6 +609,7 @@ type
     property CompilerSettingsFormat: TJclCompilerSettingsFormat read GetCompilerSettingsFormat;
     property SupportsNoConfig: Boolean read GetSupportsNoConfig;
     property SupportsPlatform: Boolean read GetSupportsPlatform;
+    property SupportsLSIF: Boolean read GetSupportsLSIF;
     property IsDcc64: Boolean read GetIsDcc64;
   end;
 
@@ -2718,6 +2720,11 @@ end;
 function TJclBorRADToolInstallation.GetSupportsPlatform: Boolean;
 begin
   Result := (RadToolKind = brBorlandDevStudio) and (VersionNumber >= 9);
+end;
+
+function TJclBorRADToolInstallation.GetSupportsLSIF: Boolean;
+begin
+  Result := (IDEVersionNumber >= 37) and (IDEUpdateNumber >= 1); // Delphi 13.1+
 end;
 
 function TJclBorRADToolInstallation.GetUpdateNeeded: Boolean;


### PR DESCRIPTION
Delphi 13.1 (Florence Release 1) introduced LSIF (Language Server Index Format) support in DelphiLSP. Starting from this version, the IDE integrates LSIF-based indexing, and the compiler exposes the `--lsif` option accordingly.

This PR adds the `SupportsLSIF` property to `TJclBorRADToolInstallation`, allowing callers to quickly detect whether the **installed IDE version** supports LSIF. The property is placed on the installation class rather than a compiler class because LSIF support is a version-level IDE feature — it reflects what the IDE as a whole supports, not a runtime compiler flag.

References:
- Delphi LSIF: https://docwiki.embarcadero.com/RADStudio/en/Delphi_LSIF
- What's New in RAD Studio 13.1 Florence: https://docwiki.embarcadero.com/RADStudio/Florence/en/13_Florence_-_Release_1#Delphi_LSP_and_LSIF