### PR TITLE
feat: Add Win64x as an independent installation target

### DIFF
--- a/jcl/install/JclInstall.pas
+++ b/jcl/install/JclInstall.pas
@@ -182,14 +182,13 @@ type
     function GetProfilesTarget(Index: Integer): TJclBorRADToolInstallation;
     function GetTargetSupportsCBuilder: Boolean;
     function GetTargetSupportsDelphi: Boolean;
+    procedure SetTargetDCC;
   protected
     constructor Create(JclDistribution: TJclDistribution;
       InstallTarget: TJclBorRADToolInstallation; ATargetPlatform: TJclBDSPlatform;
       const AGUIPage: IJediInstallPage);
-    function CompileLibraryUnits(const SubDir: string; Debug: Boolean): Boolean; overload;
-    function CompileLibraryUnits(const SubDir: string; Debug: Boolean; Win64x: Boolean): Boolean; overload;
-    function CompilePackage(const Name: string): Boolean; overload;
-    function CompilePackage(const Name: string; Win64x: Boolean): Boolean; overload;
+    function CompileLibraryUnits(const SubDir: string; Debug: Boolean): Boolean;
+    function CompilePackage(const Name: string): Boolean;
     function CompileApplication(FileName: string): Boolean;
     function DeletePackage(const Name: string): Boolean;
     procedure ConfigureBpr2Mak(const PackageFileName: string);
@@ -677,18 +676,7 @@ begin
     or ((Target.VersionNumber >= 3) and TargetSupportsDelphi);
 
   if (Target.RadToolKind = brBorlandDevStudio) and (Target.VersionNumber >= 9) then
-  begin
-    case TargetPlatform of
-      bpWin32:
-        FTargetName := Format('%s %s', [FTargetName, Personality32Bit]);
-      bpWin64:
-        FTargetName := Format('%s %s', [FTargetName, Personality64Bit]);
-      bpOSX32:
-        raise EJclBorRADException.CreateRes(@RsEOSXPlatformNotValid);
-    else
-      raise EJclBorRADException.CreateRes(@RsEPlatformNotValid);
-    end;
-  end;
+    FTargetName := Format('%s %s', [FTargetName, GetPlatformStr]);
 
   FLibReleaseDir := MakePath(Distribution.LibReleaseDirMask);
   FLibDebugDir := MakePath(Distribution.LibDebugDirMask);
@@ -769,6 +757,8 @@ begin
       Result := 'Win32';
     bpWin64:
       Result := 'Win64';
+    bpWin64x:
+      Result := 'Win64x';
     bpOSX32:
       raise EJclBorRADException.CreateRes(@RsEOSXPlatformNotValid);
   else
@@ -804,7 +794,7 @@ end;
 function TJclInstallation.GetTargetSupportsCBuilder: Boolean;
 begin
   Result := ((bpBCBuilder32 in Target.Personalities) and (TargetPlatform = bpWin32)) or
-            ((bpBCBuilder64 in Target.Personalities) and (TargetPlatform = bpWin64));
+            ((bpBCBuilder64 in Target.Personalities) and (TargetPlatform in [bpWin64, bpWin64x]));
   if Result then
   begin
     // If we don't have a command line C++ compiler we can't compile
@@ -812,23 +802,33 @@ begin
     if TargetPlatform = bpWin32 then
       Result := clBcc32 in Target.CommandLineTools
     else if TargetPlatform = bpWin64 then
-      Result := [clBcc64, clBcc64x] * Target.CommandLineTools <> [];
+      Result := clBcc64 in Target.CommandLineTools
+    else if TargetPlatform = bpWin64x then
+      Result := clBcc64x in Target.CommandLineTools;
   end;
 end;
 
 function TJclInstallation.GetTargetSupportsDelphi: Boolean;
 begin
   Result := ((bpDelphi32 in Target.Personalities) and (TargetPlatform = bpWin32)) or
-            ((bpDelphi64 in Target.Personalities) and (TargetPlatform = bpWin64));
+            ((bpDelphi64 in Target.Personalities) and (TargetPlatform in [bpWin64, bpWin64x]));
   if Result then
   begin
     // If we don't have a command line C++ compiler we can't compile
     // (fake Delphi Personality from the Web Installer)
     if TargetPlatform = bpWin32 then
       Result := clDcc32 in Target.CommandLineTools
-    else if TargetPlatform = bpWin64 then
+    else if TargetPlatform in [bpWin64, bpWin64x] then
       Result := clDcc64 in Target.CommandLineTools;
   end;
+end;
+
+procedure TJclInstallation.SetTargetDCC;
+begin
+  if (Target is TJclBDSInstallation) and (Target.IDEVersionNumber >= 9) and (FTargetPlatform in [bpWin64, bpWin64x]) then
+    Target.DCC := (Target as TJclBDSInstallation).DCC64
+  else
+    Target.DCC := Target.DCC32;
 end;
 
 procedure TJclInstallation.MarkOptionBegin(Id: Integer);
@@ -1654,7 +1654,7 @@ var
           UnitList.Delete(UnitList.IndexOf('JclDotNet.pas'));
           UnitList.Delete(UnitList.IndexOf('JclNTFS.pas'));
           UnitList.Delete(UnitList.IndexOf('mscorlib_TLB.pas'));
-          if FTargetPlatform = bpWin64 then
+          if FTargetPlatform in [bpWin64, bpWin64x] then
           begin
             UnitList.Delete(UnitList.IndexOf('pcre.pas')); // compiler: 'PCRE not supported on WIN64: use standard header'
             UnitList.Delete(UnitList.IndexOf('JclPCRE.pas')); // uses pcre.pas => same "not supported" error
@@ -1683,7 +1683,7 @@ var
 
         Target.BCC.Options.Clear;
         Target.BCC.Options.Add('-c'); // compile only
-        if FTargetPlatform <> bpWin64 then
+        if FTargetPlatform = bpWin32 then
         begin
           Target.BCC.Options.Add('-Ve'); // compatibility
           Target.BCC.Options.Add('-b'); // enum to be at least 4 bytes
@@ -1706,7 +1706,7 @@ var
           Target.BCC.Options.Add('-g');
           Target.BCC.Options.Add('-fno-limit-debug-info');
           Target.BCC.Options.Add('-fborland-extensions');
-          Target.BCC.Options.Add('-nobuiltininc');
+          if FTargetPlatform = bpWin64 then Target.BCC.Options.Add('-nobuiltininc');
           Target.BCC.Options.Add('-fexceptions');
           Target.BCC.Options.Add('-fcxx-exceptions');
           Target.BCC.Options.Add('-mstackrealign');
@@ -1732,8 +1732,10 @@ var
       finally
         DeleteFile('jcl_a2z.cpp');
         DeleteFile('jcl_a2z.obj');
+        DeleteFile('jcl_a2z.o');
         DeleteFile('jcl_z2a.cpp');
         DeleteFile('jcl_z2a.obj');
+        DeleteFile('jcl_z2a.o');
         SetCurrentDir(SaveDir);
       end;
       if not Result and Assigned(GUI) then
@@ -1743,7 +1745,12 @@ var
     I: Integer;
   begin
     // As people may only buy Delphi (without C++ Builder), we must make sure that bcc(32-64) is available before accessing the property
-    if FTargetPlatform = bpWin64 then
+    if FTargetPlatform = bpWin64x then
+    begin
+      if clBcc64x in Target.CommandLineTools then
+        Target.BCC := (Target as TJclBDSInstallation).BCC64X
+    end
+    else if FTargetPlatform = bpWin64 then
     begin
       if clBcc64 in Target.CommandLineTools then 
         Target.BCC := (Target as TJclBDSInstallation).BCC64
@@ -1790,31 +1797,21 @@ var
     end;
   end;
 
-  function CompilePackages(Win64x: Boolean): Boolean; overload;
-  begin
-    Result := CompilePackage(FullPackageFileName(Target, JclPackage), Win64x)
-      and CompilePackage(FullPackageFileName(Target, JclContainersPackage), Win64x)
-      and CompilePackage(FullPackageFileName(Target, JclDeveloperToolsPackage), Win64x);
-
-    if Result and Target.SupportsVCL then
-      Result := Result and CompilePackage(FullPackageFileName(Target, JclVclPackage), Win64x);
-  end;
-
-  function CompilePackages: Boolean; overload;
+  function CompilePackages: Boolean;
   begin
     Result := True;
     if OptionChecked[joJCLPackages] then
     begin
       MarkOptionBegin(joJCLPackages);
+      
+      SetTargetDCC;
+      
+      Result := CompilePackage(FullPackageFileName(Target, JclPackage))
+        and CompilePackage(FullPackageFileName(Target, JclContainersPackage))
+        and CompilePackage(FullPackageFileName(Target, JclDeveloperToolsPackage));
 
-      if (Target is TJclBDSInstallation) and (Target.IDEVersionNumber >= 9) and (FTargetPlatform = bpWin64) then
-        Target.DCC := (Target as TJclBDSInstallation).DCC64
-      else
-        Target.DCC := Target.DCC32;
-
-      Result := CompilePackages(False);
-      if (TargetPlatform = bpWin64) and (clBcc64x in Target.CommandLineTools) then
-        Result := Result and CompilePackages(True);
+      if Result and Target.SupportsVCL then
+        Result := Result and CompilePackage(FullPackageFileName(Target, JclVclPackage));
 
       MarkOptionEnd(joJCLPackages, Result);
     end;
@@ -2526,6 +2523,8 @@ begin
   AProfilesManager := InstallCore.ProfilesManager;
   try
     Target.OutputCallback := WriteLog;
+    SetTargetDCC;
+
     if Assigned(GUI) then
       GUI.Status := Format(LoadResString(@RsLogUninstallingJCL), [TargetName]);
     if Assigned(GUIPage) then
@@ -2704,14 +2703,6 @@ begin
 end;
 
 function TJclInstallation.CompileLibraryUnits(const SubDir: string; Debug: Boolean): Boolean;
-begin
-  Result := CompileLibraryUnits(SubDir, Debug, False);
-
-  if (TargetPlatform = bpWin64) and (clBcc64x in Target.CommandLineTools) then
-    Result := Result and CompileLibraryUnits(SubDir, Debug, True);
-end;
-
-function TJclInstallation.CompileLibraryUnits(const SubDir: string; Debug: Boolean; Win64x: Boolean): Boolean;
 
   function CopyFiles(Files: TStrings; const TargetDir: string; Overwrite: Boolean = True): Boolean;
   var
@@ -2807,7 +2798,7 @@ begin
     case TargetPlatform of
       bpWin32:
         Compiler := Target.DCC32;
-      bpWin64:
+      bpWin64, bpWin64x:
         Compiler := (Target as TJclBDSInstallation).DCC64;
       bpOSX32:
         raise EJclBorRADException.CreateRes(@RsEOSXPlatformNotValid);
@@ -2864,11 +2855,8 @@ begin
 
     if TargetSupportsCBuilder then
     begin
-      if Win64x then
-      begin
-        UnitOutputDir := Target.AdjustPathForWin64X(UnitOutputDir);
+      if TargetPlatform = bpWin64x then
         Compiler.Options.Add('-jf:coffi');
-      end;
 
       Compiler.Options.Add('-D_RTLDLL' + DirSeparator + 'NO_STRICT' + DirSeparator + 'USEPACKAGES'); // $(SYSDEFINES)
 
@@ -2926,11 +2914,6 @@ begin
 end;
 
 function TJclInstallation.CompilePackage(const Name: string): Boolean;
-begin
-  Result := CompilePackage(Name, False);
-end;
-
-function TJclInstallation.CompilePackage(const Name: string; Win64x: Boolean): Boolean;
 var
   PackageFileName: string;
   DpkPackageFileName: string;
@@ -2944,12 +2927,8 @@ begin
   DcpPath := GetDcpPath;
   ExtraOptions := '';
 
-  if Win64x then
-  begin
-    // Do not adjust BplPath as the BPLs are not platform specific
-    DcpPath := Target.AdjustPathForWin64X(DcpPath);
+  if TargetPlatform = bpWin64x then
     ExtraOptions := '-jf:coffi';
-  end;
 
   if Assigned(GUIPage) then
     GUIPage.CompilationStart(ExtractFileName(Name));
@@ -3386,7 +3365,7 @@ var
   Inst: TJclInstallation;
 begin
   if Supported then
-  try
+  begin
     Inst := TJclInstallation.Create(Self, Target, bpWin32, nil);
     FTargetInstalls.Add(Inst);
     // Win64 "virtual" target
@@ -3396,7 +3375,11 @@ begin
       Inst := TJclInstallation.Create(Self, Target, bpWin64, nil);
       FTargetInstalls.Add(Inst);
     end;
-  except
+    if clBcc64x in Target.CommandLineTools then
+    begin
+      Inst := TJclInstallation.Create(Self, Target, bpWin64x, nil);
+      FTargetInstalls.Add(Inst);
+    end;
   end;
   Result := True;
 end;
@@ -3716,13 +3699,7 @@ begin
         begin
           AInstallation := TargetInstalls[I];
           AInstallationElem := XML.Root.Items.Add('Installation');
-
-          case AInstallation.TargetPlatform of
-            bpWin64:
-              AInstallationElem.Properties.Add('Target', AInstallation.Target.VersionNumberStr + '_x64');
-            else
-              AInstallationElem.Properties.Add('Target', AInstallation.Target.VersionNumberStr);
-          end;
+          AInstallationElem.Properties.Add('Target', AInstallation.Target.VersionNumberStr + '_' + AInstallation.GetPlatformStr);
           AInstallationElem.Properties.Add('TargetName', AInstallation.TargetName);
           AInstallationElem.Properties.Add('Enabled', AInstallation.Enabled);
           AInstallationElem.Properties.Add('InstallAttempted', I <= FNbInstalled);

--- a/jcl/install/VclGui/JediGUIInstall.dfm
+++ b/jcl/install/VclGui/JediGUIInstall.dfm
@@ -11,7 +11,6 @@ object InstallFrame: TInstallFrame
     Top = 0
     Width = 5
     Height = 421
-    Align = alRight
     MinSize = 150
     ResizeStyle = rsUpdate
     OnCanResize = SplitterCanResize
@@ -21,7 +20,7 @@ object InstallFrame: TInstallFrame
     Top = 0
     Width = 360
     Height = 421
-    Align = alRight
+    Align = alClient
     BevelOuter = bvNone
     TabOrder = 0
     object LabelInstallationLog: TLabel
@@ -73,7 +72,7 @@ object InstallFrame: TInstallFrame
     Top = 0
     Width = 426
     Height = 421
-    Align = alClient
+    Align = alLeft
     BevelOuter = bvNone
     TabOrder = 1
     object LabelSelectComponents: TLabel

--- a/jcl/install/VclGui/JediGUIMain.dfm
+++ b/jcl/install/VclGui/JediGUIMain.dfm
@@ -4,7 +4,7 @@ object MainForm: TMainForm
   ActiveControl = InstallBtn
   Caption = 'RsGUIJEDIInstaller'
   ClientHeight = 582
-  ClientWidth = 792
+  ClientWidth = 940
   Color = clBtnFace
   Constraints.MinHeight = 300
   Constraints.MinWidth = 500
@@ -25,14 +25,14 @@ object MainForm: TMainForm
   object StatusBevel: TBevel
     Left = 8
     Top = 549
-    Width = 369
+    Width = 517
     Height = 19
     Anchors = [akLeft, akRight, akBottom]
   end
   object Bevel1: TBevel
     Left = 8
     Top = 534
-    Width = 775
+    Width = 923
     Height = 9
     Anchors = [akLeft, akRight, akBottom]
     Shape = bsTopLine
@@ -40,7 +40,7 @@ object MainForm: TMainForm
   object StatusLabel: TLabel
     Left = 16
     Top = 551
-    Width = 353
+    Width = 501
     Height = 14
     Anchors = [akLeft, akRight, akBottom]
     AutoSize = False
@@ -48,7 +48,7 @@ object MainForm: TMainForm
   object TitlePanel: TPanel
     Left = 0
     Top = 0
-    Width = 792
+    Width = 940
     Height = 49
     Align = alTop
     BevelWidth = 2
@@ -56,7 +56,7 @@ object MainForm: TMainForm
     Color = 9981440
     TabOrder = 3
     object JediImage: TImage
-      Left = 664
+      Left = 812
       Top = 5
       Width = 116
       Height = 31
@@ -229,7 +229,7 @@ object MainForm: TMainForm
     end
   end
   object InstallBtn: TBitBtn
-    Left = 539
+    Left = 687
     Top = 545
     Width = 75
     Height = 25
@@ -266,7 +266,7 @@ object MainForm: TMainForm
     OnClick = InstallBtnClick
   end
   object QuitBtn: TBitBtn
-    Left = 707
+    Left = 855
     Top = 545
     Width = 75
     Height = 25
@@ -321,7 +321,7 @@ object MainForm: TMainForm
   object ProductsPageControl: TPageControl
     Left = 8
     Top = 56
-    Width = 775
+    Width = 923
     Height = 465
     Anchors = [akLeft, akTop, akRight, akBottom]
     Images = ImageList
@@ -330,7 +330,7 @@ object MainForm: TMainForm
     OnChange = ProductsPageControlChange
   end
   object ProgressBar: TProgressBar
-    Left = 380
+    Left = 528
     Top = 549
     Width = 141
     Height = 19
@@ -339,7 +339,7 @@ object MainForm: TMainForm
     Visible = False
   end
   object UninstallBtn: TBitBtn
-    Left = 624
+    Left = 772
     Top = 545
     Width = 75
     Height = 25
@@ -349,7 +349,7 @@ object MainForm: TMainForm
     OnClick = UninstallBtnClick
   end
   object InstallSelectedOnlyCheckBox: TCheckBox
-    Left = 384
+    Left = 532
     Top = 551
     Width = 129
     Height = 17

--- a/jcl/source/common/JclIDEUtils.pas
+++ b/jcl/source/common/JclIDEUtils.pas
@@ -495,8 +495,6 @@ type
     function AddToLibraryBrowsingPath(const Path: string; APlatform: TJclBDSPlatform): Boolean;
     function FindFolderInPath(Folder: string; List: TStrings): Integer;
 
-    class function AdjustPathForWin64X(const Path: string): string;
-
     // package functions
       // install = package compile + registration
       // uninstall = unregistration + deletion
@@ -2101,12 +2099,6 @@ begin
     Result := False;
 end;
 
-class function TJclBorRADToolInstallation.AdjustPathForWin64X(
-  const Path: string): string;
-begin
-  Result := StringReplace(Path, '\win64', '\win64x', [rfIgnoreCase]);
-end;
-
 function TJclBorRADToolInstallation.AddToLibraryBrowsingPath(const Path: string; APlatform: TJclBDSPlatform): Boolean;
 var
   TempRawLibraryPath: TJclBorRADToolPath;
@@ -2120,14 +2112,8 @@ begin
     Result := True;
     RawLibraryBrowsingPath[APlatform] := TempRawLibraryPath;
 
-    case APlatform of
-      bpWin32:
-        if clBcc32c in CommandLineTools then
-          Result := Result and AddToLibraryBrowsingPath(Path, bpWin32c);
-      bpWin64:
-        if clBcc64x in CommandLineTools then
-          Result := Result and AddToLibraryBrowsingPath(AdjustPathForWin64X(Path), bpWin64x);
-    end;
+    if (APlatform = bpWin32) and (clBcc32c in CommandLineTools) then
+      Result := Result and AddToLibraryBrowsingPath(Path, bpWin32c);
   end
   else
     Result := False;
@@ -3784,14 +3770,8 @@ begin
     Result := True;
     RawCppBrowsingPath[APlatform] := TempRawCppPath;
 
-    case APlatform of
-      bpWin32:
-        if clBcc32c in CommandLineTools then
-          Result := Result and AddToCppBrowsingPath(Path, bpWin32c);
-      bpWin64:
-        if clBcc64x in CommandLineTools then
-          Result := Result and AddToCppBrowsingPath(Path, bpWin64x);
-    end;
+    if (APlatform = bpWin32) and (clBcc32c in CommandLineTools) then
+      Result := Result and AddToCppBrowsingPath(Path, bpWin32c);
   end
   else
     Result := False;
@@ -3810,14 +3790,8 @@ begin
     Result := True;
     RawCppSearchPath[APlatform] := TempRawCppPath;
 
-    case APlatform of
-      bpWin32:
-        if clBcc32c in CommandLineTools then
-          Result := Result and AddToCppSearchPath(Path, bpWin32c);
-      bpWin64:
-        if clBcc64x in CommandLineTools then
-          Result := Result and AddToCppSearchPath(AdjustPathForWin64X(Path), bpWin64x);
-    end;
+    if (APlatform = bpWin32) and (clBcc32c in CommandLineTools) then
+      Result := Result and AddToCppSearchPath(Path, bpWin32c);
   end
   else
     Result := False;
@@ -3836,14 +3810,8 @@ begin
     Result := True;
     RawCppLibraryPath[APlatform] := TempRawLibraryPath;
 
-    case APlatform of
-      bpWin32:
-        if clBcc32c in CommandLineTools then
-          Result := Result and AddToCppLibraryPath(Path, bpWin32c);
-      bpWin64:
-        if clBcc64x in CommandLineTools then
-          Result := Result and AddToCppLibraryPath(AdjustPathForWin64X(Path), bpWin64x);
-    end;
+    if (APlatform = bpWin32) and (clBcc32c in CommandLineTools) then
+      Result := Result and AddToCppLibraryPath(Path, bpWin32c);
   end
   else
     Result := False;
@@ -3862,14 +3830,8 @@ begin
     Result := True;
     RawCppIncludePath[APlatform] := TempRawIncludePath;
 
-    case APlatform of
-      bpWin32:
-        if clBcc32c in CommandLineTools then
-          Result := Result and AddToCppIncludePath(Path, bpWin32c);
-      bpWin64:
-        if clBcc64x in CommandLineTools then
-          Result := Result and AddToCppIncludePath(Path, bpWin64x);
-    end;
+    if (APlatform = bpWin32) and (clBcc32c in CommandLineTools) then
+      Result := Result and AddToCppIncludePath(Path, bpWin32c);
   end
   else
     Result := False;
@@ -4929,14 +4891,8 @@ begin
     Result := RemoveFromPath(TempRawCppPath, Path);
     RawCppBrowsingPath[APlatform] := TempRawCppPath;
 
-    case APlatform of
-      bpWin32:
-        if clBcc32c in CommandLineTools then
-          Result := Result and RemoveFromCppBrowsingPath(Path, bpWin32c);
-      bpWin64:
-        if clBcc64x in CommandLineTools then
-          Result := Result and RemoveFromCppBrowsingPath(Path, bpWin64x);
-    end;
+    if (APlatform = bpWin32) and (clBcc32c in CommandLineTools) then
+      Result := Result and RemoveFromCppBrowsingPath(Path, bpWin32c);
   end
   else
     Result := False;
@@ -4954,14 +4910,8 @@ begin
     Result := RemoveFromPath(TempRawCppPath, Path);
     RawCppSearchPath[APlatform] := TempRawCppPath;
 
-    case APlatform of
-      bpWin32:
-        if clBcc32c in CommandLineTools then
-          Result := Result and RemoveFromCppSearchPath(Path, bpWin32c);
-      bpWin64:
-        if clBcc64x in CommandLineTools then
-          Result := Result and RemoveFromCppSearchPath(AdjustPathForWin64X(Path), bpWin64x);
-    end;
+    if (APlatform = bpWin32) and (clBcc32c in CommandLineTools) then
+      Result := Result and RemoveFromCppSearchPath(Path, bpWin32c);
   end
   else
     Result := False;
@@ -4979,14 +4929,8 @@ begin
     Result := RemoveFromPath(TempRawLibraryPath, Path);
     RawCppLibraryPath[APlatform] := TempRawLibraryPath;
 
-    case APlatform of
-      bpWin32:
-        if clBcc32c in CommandLineTools then
-          Result := Result and RemoveFromCppLibraryPath(Path, bpWin32c);
-      bpWin64:
-        if clBcc64x in CommandLineTools then
-          Result := Result and RemoveFromCppLibraryPath(AdjustPathForWin64X(Path), bpWin64x);
-    end;
+    if (APlatform = bpWin32) and (clBcc32c in CommandLineTools) then
+      Result := Result and RemoveFromCppLibraryPath(Path, bpWin32c);
   end
   else
     Result := False;
@@ -5004,14 +4948,8 @@ begin
     Result := RemoveFromPath(TempRawIncludePath, Path);
     RawCppIncludePath[APlatform] := TempRawIncludePath;
 
-    case APlatform of
-      bpWin32:
-        if clBcc32c in CommandLineTools then
-          Result := Result and RemoveFromCppIncludePath(Path, bpWin32c);
-      bpWin64:
-        if clBcc64x in CommandLineTools then
-          Result := Result and RemoveFromCppIncludePath(Path, bpWin64x);
-    end;
+    if (APlatform = bpWin32) and (clBcc32c in CommandLineTools) then
+      Result := Result and RemoveFromCppIncludePath(Path, bpWin32c);
   end
   else
     Result := False;


### PR DESCRIPTION
## Problem

- JCL currently supports only Win32 and Win64 as target platforms in the installer UI. Win64x is installed alongside Win64, with its output directory determined by the following code:

  ``` pascal
  class function TJclBorRADToolInstallation.AdjustPathForWin64X(const Path: string): string;
  begin
    Result := StringReplace(Path, '\win64', '\win64x', [rfIgnoreCase]);
  end;
  ```

  This is a simple string replacement. Since the Win64 output directory is user-customizable in the installer, if any part of the user-selected path contains the string "Win64", or if it contains no "Win64" at all, serious issues will arise. This is a bug.

- Win64x is currently the default and primary platform in C++Builder. It is a fully independent target platform, on equal footing with Win32, Win64, and WinARM64EC (not yet supported by JCL). Treating it as a sub-platform of Win64 is incorrect.

## What This PR Does

- **Adds Win64x as a new installation wizard page**
  Just like Win32 and Win64, users can now specify installation options and an output directory for Win64x independently, completely decoupled from Win64.

- **Renames platform display labels in the installer UI**
  Previously shown as *RAD Studio 32 bit* / *RAD Studio 64 bit*, these have been renamed to *RAD Studio Win32*, *Win64*, and *Win64x*, aligning with the platform identifiers used in the IDE and avoiding confusion with *32-bit IDE* / *64-bit IDE*.

- **Increases the default width of the installer main window**
  The added width ensures that, when installing for at least one IDE, the `TPageControl` tabs do not wrap to a second line, improving UI usability.

- **Fixes Expert package not being properly uninstalled from the 64-bit IDE**
  The current JCL version uninstalls cleanly from the 32-bit IDE, but the Expert package fails to uninstall correctly from the 64-bit IDE. This is because the uninstall process does not specify the DCC in use (the unregistration functions in `JclIDEUtils` rely on the current DCC to determine which registry key value to delete: `default` or `x64`). Since this fix involves platform detection, it has been included in this PR.

<img width="1412" height="921" alt="image" src="https://github.com/user-attachments/assets/0278ba38-f35b-4004-9f00-4778935acef5" />

## Impact

By treating Win64x as a fully independent platform, the codebase is actually simplified rather than made more complex. As evident from the changed files, most modifications consist of removing conditional checks rather than adding new ones.

This PR does not break any existing code in JCL. 

Tested successfully on RAD Studio 11.3 32-bit IDE (Win32, Win64) and RAD Studio 13.1 32-bit and 64-bit IDE (Win32, Win64, Win64x).