### PR TITLE
Reduce false positives in the 64-bit TJclStackInfoList.ValidCallSite

### DIFF
--- a/jcl/source/windows/JclDebug.pas
+++ b/jcl/source/windows/JclDebug.pas
@@ -6615,10 +6615,12 @@ begin
           // 7 bytes, "CALL NEAR [EAX+EAX+$1234567]" (FF /2) where Reg = 010, Mod = 10 and RM = 100
           CallInstructionSize := 7
         else
+{$IFNDEF CPUX64} //The 9A cp call opcode is not valid in 64-bit mode
         if ((CodeDWORD8 and $0000FF00) = $00009A00) then
           // 7 bytes, "CALL FAR $1234:12345678" (9A ptr16:32)
           CallInstructionSize := 7
         else
+{$ENDIF}
           Result := False;
         // Because we're not doing a complete disassembly, we will potentially report
         // false positives. If there is odd code that uses the CALL 16:32 format, we


### PR DESCRIPTION
TJclStackInfoList.ValidCallSite checks for the "9A cp" opcode, but this is not valid under 64-bit. From the Intel Software Developer's Manual:
<img width="796" height="525" alt="image" src="https://github.com/user-attachments/assets/07c4483b-4e8d-4e3d-80ca-96cb75a9013a" />

In order to reduce the number of false positives under 64-bit this change excludes checking for the "9A cp" opcode if CPUX64 is defined.