### PR TITLE
changes to fix PE header corruption when inserting exception stack tr…

### DIFF
--- a/jcl/source/windows/JclDebug.pas
+++ b/jcl/source/windows/JclDebug.pas
@@ -2631,7 +2631,11 @@ var
     I: Integer;
   begin
     for I := Low(ImageSectionHeaders) to High(ImageSectionHeaders) do
-      ImageSectionHeaders[I].PointerToRawData := ImageSectionHeaders[I].PointerToRawData + AOffset;
+      // Sections with no raw data on disk (e.g. .bss, .tls) have PointerToRawData = 0
+      // and must keep it. Only shift sections that actually have raw data, otherwise
+      // they end up with a bogus non-zero file offset.
+      if ImageSectionHeaders[I].PointerToRawData <> 0 then
+        ImageSectionHeaders[I].PointerToRawData := ImageSectionHeaders[I].PointerToRawData + AOffset;
   end;
 
   procedure FillZeros(AStream: TStream; ACount: Integer);
@@ -2697,13 +2701,19 @@ var
       raise EJclPeImageError.CreateRes(@SWriteError);
   end;
 
-  procedure CheckHeadersSpace(AStream: TStream);
+  procedure CheckHeadersSpace(AStream: TStream; AFileAlignment: DWORD; var ASizeOfHeaders: DWORD);
   begin
     if ImageSectionHeaders[0].PointerToRawData < ImageSectionHeadersPosition +
        (SizeOf(TImageSectionHeader) * (Length(ImageSectionHeaders) + 1)) then
     begin
-      MoveData(AStream, ImageSectionHeaders[0].PointerToRawData, NtHeaders64.OptionalHeader.FileAlignment);
-      MovePointerToRawData(NtHeaders64.OptionalHeader.FileAlignment);
+      MoveData(AStream, ImageSectionHeaders[0].PointerToRawData, AFileAlignment);
+      MovePointerToRawData(AFileAlignment);
+      // The header area was grown by one FileAlignment block to make room for the new
+      // section header. SizeOfHeaders must grow with it; otherwise the section table
+      // extends past SizeOfHeaders and the first section's raw data no longer starts at
+      // SizeOfHeaders. The Windows loader tolerates that, but strict PE validators
+      // (e.g. signtool) reject the image with ERROR_BAD_EXE_FORMAT (0x800700C1).
+      Inc(ASizeOfHeaders, AFileAlignment);
       WriteSectionHeaders(AStream, ImageSectionHeadersPosition);
     end;
   end;
@@ -2759,6 +2769,9 @@ begin
               Exit;
             end;
 
+            // Check if there is enough space for an additional section header
+            CheckHeadersSpace(ImageStream, NtHeaders32.OptionalHeader.FileAlignment, NtHeaders32.OptionalHeader.SizeOfHeaders);
+
             JclDebugSectionPosition := ImageSectionHeadersPosition + (SizeOf(ImageSectionHeaders[0]) * Length(ImageSectionHeaders));
             LastSection := @ImageSectionHeaders[High(ImageSectionHeaders)];
 
@@ -2801,8 +2814,8 @@ begin
               Exit;
             end;
 
-            // Check if there is enough space for additional header
-            CheckHeadersSpace(ImageStream);
+            // Check if there is enough space for an additional section header
+            CheckHeadersSpace(ImageStream, NtHeaders64.OptionalHeader.FileAlignment, NtHeaders64.OptionalHeader.SizeOfHeaders);
 
             JclDebugSectionPosition := ImageSectionHeadersPosition + (SizeOf(ImageSectionHeaders[0]) * Length(ImageSectionHeaders));
             LastSection := @ImageSectionHeaders[High(ImageSectionHeaders)];
@@ -2857,6 +2870,12 @@ begin
   finally
     ImageStream.Free;
   end;
+  // Inserting the section invalidated the original PE checksum. Recompute it now that
+  // the exclusive stream is closed (MapAndLoad needs its own handle). Signing tools
+  // rewrite the checksum themselves, but a correct value is expected by some loaders
+  // and validators.
+  if Result then
+    PeUpdateCheckSum(ExecutableFileName);
 end;
 
 //=== { TJclBinDebugGenerator } ==============================================

--- a/jcl/source/windows/JclDebug.pas
+++ b/jcl/source/windows/JclDebug.pas
@@ -2631,11 +2631,13 @@ var
     I: Integer;
   begin
     for I := Low(ImageSectionHeaders) to High(ImageSectionHeaders) do
+    begin
       // Sections with no raw data on disk (e.g. .bss, .tls) have PointerToRawData = 0
       // and must keep it. Only shift sections that actually have raw data, otherwise
       // they end up with a bogus non-zero file offset.
       if ImageSectionHeaders[I].PointerToRawData <> 0 then
         ImageSectionHeaders[I].PointerToRawData := ImageSectionHeaders[I].PointerToRawData + AOffset;
+    end;
   end;
 
   procedure FillZeros(AStream: TStream; ACount: Integer);
@@ -2701,13 +2703,14 @@ var
       raise EJclPeImageError.CreateRes(@SWriteError);
   end;
 
-  procedure CheckHeadersSpace(AStream: TStream; AFileAlignment: DWORD; var ASizeOfHeaders: DWORD);
+  procedure AdjustHeadersSpace(AStream: TStream; AFileAlignment: DWORD; var ASizeOfHeaders: DWORD);
   begin
     if ImageSectionHeaders[0].PointerToRawData < ImageSectionHeadersPosition +
        (SizeOf(TImageSectionHeader) * (Length(ImageSectionHeaders) + 1)) then
     begin
       MoveData(AStream, ImageSectionHeaders[0].PointerToRawData, AFileAlignment);
       MovePointerToRawData(AFileAlignment);
+
       // The header area was grown by one FileAlignment block to make room for the new
       // section header. SizeOfHeaders must grow with it; otherwise the section table
       // extends past SizeOfHeaders and the first section's raw data no longer starts at
@@ -2769,8 +2772,8 @@ begin
               Exit;
             end;
 
-            // Check if there is enough space for an additional section header
-            CheckHeadersSpace(ImageStream, NtHeaders32.OptionalHeader.FileAlignment, NtHeaders32.OptionalHeader.SizeOfHeaders);
+            // Make room for an additional section header (and grow SizeOfHeaders) if needed
+            AdjustHeadersSpace(ImageStream, NtHeaders32.OptionalHeader.FileAlignment, NtHeaders32.OptionalHeader.SizeOfHeaders);
 
             JclDebugSectionPosition := ImageSectionHeadersPosition + (SizeOf(ImageSectionHeaders[0]) * Length(ImageSectionHeaders));
             LastSection := @ImageSectionHeaders[High(ImageSectionHeaders)];
@@ -2814,8 +2817,8 @@ begin
               Exit;
             end;
 
-            // Check if there is enough space for an additional section header
-            CheckHeadersSpace(ImageStream, NtHeaders64.OptionalHeader.FileAlignment, NtHeaders64.OptionalHeader.SizeOfHeaders);
+            // Make room for an additional section header (and grow SizeOfHeaders) if needed
+            AdjustHeadersSpace(ImageStream, NtHeaders64.OptionalHeader.FileAlignment, NtHeaders64.OptionalHeader.SizeOfHeaders);
 
             JclDebugSectionPosition := ImageSectionHeadersPosition + (SizeOf(ImageSectionHeaders[0]) * Length(ImageSectionHeaders));
             LastSection := @ImageSectionHeaders[High(ImageSectionHeaders)];
@@ -2870,6 +2873,7 @@ begin
   finally
     ImageStream.Free;
   end;
+
   // Inserting the section invalidated the original PE checksum. Recompute it now that
   // the exclusive stream is closed (MapAndLoad needs its own handle). Signing tools
   // rewrite the checksum themselves, but a correct value is expected by some loaders

--- a/jcl/source/windows/JclPeImage.pas
+++ b/jcl/source/windows/JclPeImage.pas
@@ -5279,11 +5279,43 @@ function PeInsertSection(const FileName: TFileName; SectionStream: TStream; Sect
     if (Value mod Alignment) <> 0 then
       Value := ((Value div Alignment) + 1) * Alignment;
   end;
+  // Insert ACount zero bytes at file offset AOffset in the in-memory image, shifting
+  // everything from AOffset onward forward by ACount. Used to enlarge the header area
+  // so that another section header fits before the first section's raw data.
+  // NOTE: ImageStream.Memory may be reallocated, so callers must re-fetch any pointers
+  // into it afterwards.
+  procedure InsertHeaderSpace(ImageStream: TMemoryStream; AOffset, ACount: DWORD);
+  var
+    OldSize: Int64;
+    CurPos: Int64;
+    ChunkSize: Integer;
+    Buffer: array of Byte;
+  begin
+    OldSize := ImageStream.Size;
+    ImageStream.Size := OldSize + ACount;
+    SetLength(Buffer, 1024 * 1024);
+    CurPos := OldSize;
+    while CurPos > AOffset do
+    begin
+      ChunkSize := Length(Buffer);
+      if CurPos - ChunkSize < AOffset then
+        ChunkSize := Integer(CurPos - AOffset);
+      Dec(CurPos, ChunkSize);
+      ImageStream.Position := CurPos;
+      ImageStream.ReadBuffer(Buffer[0], ChunkSize);
+      ImageStream.Position := CurPos + ACount;
+      ImageStream.WriteBuffer(Buffer[0], ChunkSize);
+    end;
+    // zero the inserted gap (ACount = FileAlignment <= 64K, fits in Buffer)
+    FillChar(Buffer[0], ACount, 0);
+    ImageStream.Position := AOffset;
+    ImageStream.WriteBuffer(Buffer[0], ACount);
+  end;
   function PeInsertSection32(ImageStream: TMemoryStream): Boolean;
   var
     NtHeaders: PImageNtHeaders32;
-    Sections, LastSection, NewSection: PImageSectionHeader;
-    VirtualAlignedSize: DWORD;
+    Sections, LastSection, NewSection, SecPtr: PImageSectionHeader;
+    VirtualAlignedSize, FileAlignment: DWORD;
     I, X, NeedFill: Integer;
     SectionDataSize: Integer;
     UTF8Name: TUTF8String;
@@ -5302,10 +5334,37 @@ function PeInsertSection(const FileName: TFileName; SectionStream: TStream; Sect
         Exit;
       end;
 
+      FileAlignment := NtHeaders^.OptionalHeader.FileAlignment;
+
       LastSection := Sections;
       Inc(LastSection, NtHeaders^.FileHeader.NumberOfSections - 1);
       NewSection := LastSection;
       Inc(NewSection);
+
+      // Make room in the header area when the new section header would not fit before
+      // the first section's raw data. Without this the header is written over the first
+      // section's data; growing SizeOfHeaders in step keeps the image valid for strict
+      // PE validators (e.g. signtool, which otherwise fails with ERROR_BAD_EXE_FORMAT).
+      if TJclAddr(NewSection) - TJclAddr(ImageStream.Memory) + DWORD(SizeOf(TImageSectionHeader)) > Sections^.PointerToRawData then
+      begin
+        InsertHeaderSpace(ImageStream, Sections^.PointerToRawData, FileAlignment);
+        // ImageStream.Memory may have been reallocated -> re-fetch the pointers.
+        NtHeaders := PeMapImgNtHeaders32(ImageStream.Memory);
+        Sections := PeMapImgSections32(NtHeaders);
+        SecPtr := Sections;
+        for I := 0 to NtHeaders^.FileHeader.NumberOfSections - 1 do
+        begin
+          // sections with no raw data on disk keep PointerToRawData = 0
+          if SecPtr^.PointerToRawData <> 0 then
+            Inc(SecPtr^.PointerToRawData, FileAlignment);
+          Inc(SecPtr);
+        end;
+        Inc(NtHeaders^.OptionalHeader.SizeOfHeaders, FileAlignment);
+        LastSection := Sections;
+        Inc(LastSection, NtHeaders^.FileHeader.NumberOfSections - 1);
+        NewSection := LastSection;
+        Inc(NewSection);
+      end;
 
       // Increase the number of sections
       Inc(NtHeaders^.FileHeader.NumberOfSections);
@@ -5353,8 +5412,8 @@ function PeInsertSection(const FileName: TFileName; SectionStream: TStream; Sect
   function PeInsertSection64(ImageStream: TMemoryStream): Boolean;
   var
     NtHeaders: PImageNtHeaders64;
-    Sections, LastSection, NewSection: PImageSectionHeader;
-    VirtualAlignedSize: DWORD;
+    Sections, LastSection, NewSection, SecPtr: PImageSectionHeader;
+    VirtualAlignedSize, FileAlignment: DWORD;
     I, X, NeedFill: Integer;
     SectionDataSize: Integer;
     UTF8Name: TUTF8String;
@@ -5373,10 +5432,37 @@ function PeInsertSection(const FileName: TFileName; SectionStream: TStream; Sect
         Exit;
       end;
 
+      FileAlignment := NtHeaders^.OptionalHeader.FileAlignment;
+
       LastSection := Sections;
       Inc(LastSection, NtHeaders^.FileHeader.NumberOfSections - 1);
       NewSection := LastSection;
       Inc(NewSection);
+
+      // Make room in the header area when the new section header would not fit before
+      // the first section's raw data. Without this the header is written over the first
+      // section's data; growing SizeOfHeaders in step keeps the image valid for strict
+      // PE validators (e.g. signtool, which otherwise fails with ERROR_BAD_EXE_FORMAT).
+      if TJclAddr(NewSection) - TJclAddr(ImageStream.Memory) + DWORD(SizeOf(TImageSectionHeader)) > Sections^.PointerToRawData then
+      begin
+        InsertHeaderSpace(ImageStream, Sections^.PointerToRawData, FileAlignment);
+        // ImageStream.Memory may have been reallocated -> re-fetch the pointers.
+        NtHeaders := PeMapImgNtHeaders64(ImageStream.Memory);
+        Sections := PeMapImgSections64(NtHeaders);
+        SecPtr := Sections;
+        for I := 0 to NtHeaders^.FileHeader.NumberOfSections - 1 do
+        begin
+          // sections with no raw data on disk keep PointerToRawData = 0
+          if SecPtr^.PointerToRawData <> 0 then
+            Inc(SecPtr^.PointerToRawData, FileAlignment);
+          Inc(SecPtr);
+        end;
+        Inc(NtHeaders^.OptionalHeader.SizeOfHeaders, FileAlignment);
+        LastSection := Sections;
+        Inc(LastSection, NtHeaders^.FileHeader.NumberOfSections - 1);
+        NewSection := LastSection;
+        Inc(NewSection);
+      end;
 
       // Increase the number of sections
       Inc(NtHeaders^.FileHeader.NumberOfSections);
@@ -5442,7 +5528,11 @@ begin
     end;
 
     if Result then
+    begin
       ImageStream.SaveToFile(FileName);
+      // The inserted section invalidated the original PE checksum; recompute it.
+      PeUpdateCheckSum(FileName);
+    end;
   finally
     ImageStream.Free;
   end;

--- a/jcl/source/windows/JclPeImage.pas
+++ b/jcl/source/windows/JclPeImage.pas
@@ -5279,6 +5279,7 @@ function PeInsertSection(const FileName: TFileName; SectionStream: TStream; Sect
     if (Value mod Alignment) <> 0 then
       Value := ((Value div Alignment) + 1) * Alignment;
   end;
+
   // Insert ACount zero bytes at file offset AOffset in the in-memory image, shifting
   // everything from AOffset onward forward by ACount. Used to enlarge the header area
   // so that another section header fits before the first section's raw data.
@@ -5311,10 +5312,53 @@ function PeInsertSection(const FileName: TFileName; SectionStream: TStream; Sect
     ImageStream.Position := AOffset;
     ImageStream.WriteBuffer(Buffer[0], ACount);
   end;
+
+  // Ensure the section header table has room for one more entry before the first
+  // section's raw data. When it does not, a single FileAlignment block of zero bytes
+  // is inserted into the header area and every populated section's PointerToRawData is
+  // shifted forward to match; the function then returns True so the caller can grow
+  // SizeOfHeaders in step. Without that the section table runs past SizeOfHeaders and,
+  // while Windows still loads the image, strict PE validators such as signtool reject
+  // it with ERROR_BAD_EXE_FORMAT (0x800700C1).
+  // The section table sits at the same file offset for 32- and 64-bit images, so the
+  // 32-bit mapping helpers locate it correctly for both targets; only the per-target
+  // OptionalHeader.SizeOfHeaders (updated by the caller) lives at a different offset.
+  // NOTE: ImageStream.Memory may be reallocated, so the caller must re-fetch any
+  // pointers into it whenever this returns True.
+  function EnsureSectionHeaderSpace(ImageStream: TMemoryStream;
+    NumberOfSections: Integer; FileAlignment: DWORD): Boolean;
+  var
+    Sections, SecPtr: PImageSectionHeader;
+    FirstRawData: DWORD;
+    NewSectionTableEnd: TJclAddr;
+    I: Integer;
+  begin
+    Sections := PeMapImgSections32(PeMapImgNtHeaders32(ImageStream.Memory));
+    FirstRawData := Sections^.PointerToRawData;
+    NewSectionTableEnd := (TJclAddr(Sections) - TJclAddr(ImageStream.Memory)) +
+      TJclAddr(SizeOf(TImageSectionHeader)) * TJclAddr(NumberOfSections + 1);
+    Result := NewSectionTableEnd > FirstRawData;
+    if not Result then
+      Exit;
+
+    InsertHeaderSpace(ImageStream, FirstRawData, FileAlignment);
+
+    // ImageStream.Memory may have been reallocated -> re-fetch before shifting.
+    Sections := PeMapImgSections32(PeMapImgNtHeaders32(ImageStream.Memory));
+    SecPtr := Sections;
+    for I := 0 to NumberOfSections - 1 do
+    begin
+      // Sections with no raw data on disk (e.g. .bss, .tls) keep PointerToRawData = 0.
+      if SecPtr^.PointerToRawData <> 0 then
+        Inc(SecPtr^.PointerToRawData, FileAlignment);
+      Inc(SecPtr);
+    end;
+  end;
+
   function PeInsertSection32(ImageStream: TMemoryStream): Boolean;
   var
     NtHeaders: PImageNtHeaders32;
-    Sections, LastSection, NewSection, SecPtr: PImageSectionHeader;
+    Sections, LastSection, NewSection: PImageSectionHeader;
     VirtualAlignedSize, FileAlignment: DWORD;
     I, X, NeedFill: Integer;
     SectionDataSize: Integer;
@@ -5336,35 +5380,21 @@ function PeInsertSection(const FileName: TFileName; SectionStream: TStream; Sect
 
       FileAlignment := NtHeaders^.OptionalHeader.FileAlignment;
 
+      // Make room for the new section header when it would not fit before the first
+      // section's raw data, growing SizeOfHeaders in step so the image stays valid for
+      // strict PE validators (e.g. signtool, ERROR_BAD_EXE_FORMAT otherwise).
+      if EnsureSectionHeaderSpace(ImageStream, NtHeaders^.FileHeader.NumberOfSections, FileAlignment) then
+      begin
+        // ImageStream.Memory was reallocated -> re-fetch the typed pointers.
+        NtHeaders := PeMapImgNtHeaders32(ImageStream.Memory);
+        Sections := PeMapImgSections32(NtHeaders);
+        Inc(NtHeaders^.OptionalHeader.SizeOfHeaders, FileAlignment);
+      end;
+
       LastSection := Sections;
       Inc(LastSection, NtHeaders^.FileHeader.NumberOfSections - 1);
       NewSection := LastSection;
       Inc(NewSection);
-
-      // Make room in the header area when the new section header would not fit before
-      // the first section's raw data. Without this the header is written over the first
-      // section's data; growing SizeOfHeaders in step keeps the image valid for strict
-      // PE validators (e.g. signtool, which otherwise fails with ERROR_BAD_EXE_FORMAT).
-      if TJclAddr(NewSection) - TJclAddr(ImageStream.Memory) + DWORD(SizeOf(TImageSectionHeader)) > Sections^.PointerToRawData then
-      begin
-        InsertHeaderSpace(ImageStream, Sections^.PointerToRawData, FileAlignment);
-        // ImageStream.Memory may have been reallocated -> re-fetch the pointers.
-        NtHeaders := PeMapImgNtHeaders32(ImageStream.Memory);
-        Sections := PeMapImgSections32(NtHeaders);
-        SecPtr := Sections;
-        for I := 0 to NtHeaders^.FileHeader.NumberOfSections - 1 do
-        begin
-          // sections with no raw data on disk keep PointerToRawData = 0
-          if SecPtr^.PointerToRawData <> 0 then
-            Inc(SecPtr^.PointerToRawData, FileAlignment);
-          Inc(SecPtr);
-        end;
-        Inc(NtHeaders^.OptionalHeader.SizeOfHeaders, FileAlignment);
-        LastSection := Sections;
-        Inc(LastSection, NtHeaders^.FileHeader.NumberOfSections - 1);
-        NewSection := LastSection;
-        Inc(NewSection);
-      end;
 
       // Increase the number of sections
       Inc(NtHeaders^.FileHeader.NumberOfSections);
@@ -5412,7 +5442,7 @@ function PeInsertSection(const FileName: TFileName; SectionStream: TStream; Sect
   function PeInsertSection64(ImageStream: TMemoryStream): Boolean;
   var
     NtHeaders: PImageNtHeaders64;
-    Sections, LastSection, NewSection, SecPtr: PImageSectionHeader;
+    Sections, LastSection, NewSection: PImageSectionHeader;
     VirtualAlignedSize, FileAlignment: DWORD;
     I, X, NeedFill: Integer;
     SectionDataSize: Integer;
@@ -5434,35 +5464,21 @@ function PeInsertSection(const FileName: TFileName; SectionStream: TStream; Sect
 
       FileAlignment := NtHeaders^.OptionalHeader.FileAlignment;
 
+      // Make room for the new section header when it would not fit before the first
+      // section's raw data, growing SizeOfHeaders in step so the image stays valid for
+      // strict PE validators (e.g. signtool, ERROR_BAD_EXE_FORMAT otherwise).
+      if EnsureSectionHeaderSpace(ImageStream, NtHeaders^.FileHeader.NumberOfSections, FileAlignment) then
+      begin
+        // ImageStream.Memory was reallocated -> re-fetch the typed pointers.
+        NtHeaders := PeMapImgNtHeaders64(ImageStream.Memory);
+        Sections := PeMapImgSections64(NtHeaders);
+        Inc(NtHeaders^.OptionalHeader.SizeOfHeaders, FileAlignment);
+      end;
+
       LastSection := Sections;
       Inc(LastSection, NtHeaders^.FileHeader.NumberOfSections - 1);
       NewSection := LastSection;
       Inc(NewSection);
-
-      // Make room in the header area when the new section header would not fit before
-      // the first section's raw data. Without this the header is written over the first
-      // section's data; growing SizeOfHeaders in step keeps the image valid for strict
-      // PE validators (e.g. signtool, which otherwise fails with ERROR_BAD_EXE_FORMAT).
-      if TJclAddr(NewSection) - TJclAddr(ImageStream.Memory) + DWORD(SizeOf(TImageSectionHeader)) > Sections^.PointerToRawData then
-      begin
-        InsertHeaderSpace(ImageStream, Sections^.PointerToRawData, FileAlignment);
-        // ImageStream.Memory may have been reallocated -> re-fetch the pointers.
-        NtHeaders := PeMapImgNtHeaders64(ImageStream.Memory);
-        Sections := PeMapImgSections64(NtHeaders);
-        SecPtr := Sections;
-        for I := 0 to NtHeaders^.FileHeader.NumberOfSections - 1 do
-        begin
-          // sections with no raw data on disk keep PointerToRawData = 0
-          if SecPtr^.PointerToRawData <> 0 then
-            Inc(SecPtr^.PointerToRawData, FileAlignment);
-          Inc(SecPtr);
-        end;
-        Inc(NtHeaders^.OptionalHeader.SizeOfHeaders, FileAlignment);
-        LastSection := Sections;
-        Inc(LastSection, NtHeaders^.FileHeader.NumberOfSections - 1);
-        NewSection := LastSection;
-        Inc(NewSection);
-      end;
 
       // Increase the number of sections
       Inc(NtHeaders^.FileHeader.NumberOfSections);


### PR DESCRIPTION
Fix JCLDEBUG insertion producing a PE that signtool rejects (0x800700C1)

When the header area lacks room for the new JCLDEBUG section header,
InsertDebugDataIntoExecutableFile grows it but never updated
OptionalHeader.SizeOfHeaders, and gave .bss/.tls a bogus PointerToRawData.
The loader tolerates this; signtool rejects it with ERROR_BAD_EXE_FORMAT.

- JclDebug.pas: CheckHeadersSpace updates SizeOfHeaders and is now called
  from both the 32-bit and 64-bit paths (32-bit had no header room check);
  MovePointerToRawData skips zero-raw sections; recompute PE checksum.
- JclPeImage.pas: same fix in generic PeInsertSection32/64 via a shared
  InsertHeaderSpace helper.

Co-Authored-By: Claude Opus 4.8 (1M context)