### PR TITLE
Added dpm package .dspec

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 *	text=auto
 *.pas	filter=rcs-keywords
+
+# applies post commit hook to dspec
+*.dspec filter=insert-hash

--- a/gitconfig.bat
+++ b/gitconfig.bat
@@ -1,0 +1,6 @@
+REM ensure the current commit hash is added to *.dspec
+REM Only needed for package publishing - for owner use only.
+
+git config filter.insert-hash.smudge "sh -c 'hash=$(git rev-parse HEAD); sed s/#HASH#/Id:$hash/g'"
+git config filter.insert-hash.clean "sh -c 'sed -E 's/Id:[0-9a-fA-F]{40}/#HASH#/g''"
+copy post-commit.txt .git\hooks\post-commit

--- a/jcl/Jedi.JCL.dspec
+++ b/jcl/Jedi.JCL.dspec
@@ -1,0 +1,47 @@
+# DPM package spec file
+min dpm client version: 1.0.0
+metadata:
+  id: Jedi.JCL
+  version: 2.8.9330
+  description: The JEDI Code Library (JCL) consists of a set of thoroughly tested and fully documented utility functions and non-visual classes which can be instantly reused in your Delphi and C++ Builder projects.
+  authors:
+    - Various
+  projectUrl: https://github.com/project-jedi/jcl
+  repositoryUrl: https://github.com/project-jedi/jcl
+  repositoryCommit: '#HASH#'
+  license: MPL-1.1
+  copyright: Various
+  tags:
+    - jcl
+    - jedi
+  readme: ../readme.md
+variables:
+  packagesource: d$libsuffixShort$
+targetPlatforms:
+  - compiler from: delphixe2
+    compiler to: delphi13.0
+    platforms:
+      - win32
+      - win64
+templates:
+  - name: default
+    source:
+      - src: source/**.pas
+      - src: source/include/**.inc
+      - src: source/**.res
+      - src: /source/windows/obj/**.*
+      - src: packages/$packageSource$/Jcl.dproj
+      - src: packages/$packageSource$/Jcl.dpk
+      - src: packages/$packageSource$/Jcl.res
+      - src: packages/$packageSource$/JclContainers.dproj
+      - src: packages/$packageSource$/JclContainers.dpk
+      - src: packages/$packageSource$/JclContainers.res
+    build:
+      - project: packages/$packageSource$/Jcl.dproj
+        searchPaths:
+          - source/include/jedi
+          - source/include
+      - project: packages/$packageSource$/JclContainers.dproj
+        searchPaths:
+          - source/include/jedi
+          - source/include

--- a/post-commit.txt
+++ b/post-commit.txt
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Post commit hook to force all .dspec and .dspec.yaml files to always have current commit hash
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Define the source folder to search
+# In this project
+SOURCE_FOLDER="./"
+
+echo -e "${YELLOW}Post-commit hook: Processing .dspec and .dspec.yaml files in ${SOURCE_FOLDER} folder${NC}"
+
+# Find all .dspec and .dspec.yaml files in the Source folder
+DSPEC_FILES=$(find "$SOURCE_FOLDER" \( -name "*.dspec" -o -name "*.dspec.yaml" \) -type f 2>/dev/null)
+
+if [ -z "$DSPEC_FILES" ]; then
+    echo -e "${YELLOW}No .dspec or .dspec.yaml files found in ${SOURCE_FOLDER} folder${NC}"
+    exit 0
+fi
+
+echo -e "${YELLOW}Found files:${NC}"
+echo "$DSPEC_FILES" | while read -r file; do
+    echo -e "  ${YELLOW}$file${NC}"
+done
+
+# Process each .dspec file
+echo "$DSPEC_FILES" | while read -r TARGET_FILE; do
+    echo -e "\n${YELLOW}Processing: ${TARGET_FILE}${NC}"
+    
+    # Check if the target file exists
+    if [ -f "$TARGET_FILE" ]; then
+        echo -e "${RED}Deleting ${TARGET_FILE}${NC}"
+        rm "$TARGET_FILE"
+        
+        # Verify deletion
+        if [ ! -f "$TARGET_FILE" ]; then
+            echo -e "${GREEN}File successfully deleted${NC}"
+        else
+            echo -e "${RED}Error: Failed to delete ${TARGET_FILE}${NC}"
+            exit 1
+        fi
+    else
+        echo -e "${YELLOW}File ${TARGET_FILE} does not exist, skipping deletion${NC}"
+    fi
+
+    # Force checkout the file from the repository
+    echo -e "${YELLOW}Force checking out ${TARGET_FILE} from HEAD${NC}"
+
+    # Use git checkout to restore the file from the latest commit
+    git checkout HEAD -- "$TARGET_FILE"
+
+    # Check if the checkout was successful
+    if [ $? -eq 0 ]; then
+        if [ -f "$TARGET_FILE" ]; then
+            echo -e "${GREEN}Successfully restored ${TARGET_FILE} from repository${NC}"
+        else
+            echo -e "${YELLOW}File ${TARGET_FILE} was not restored (may not exist in repository)${NC}"
+        fi
+    else
+        echo -e "${RED}Error: Failed to checkout ${TARGET_FILE}${NC}"
+        exit 1
+    fi
+done
+
+echo -e "\n${GREEN}Post-commit hook completed successfully${NC}"


### PR DESCRIPTION
Hi

I would love to see JCL on [DPM](https://delphi.dev) - This PR is to help that happen. I created a package dspec file for jcl.

To publish packages, sign up on https://delphi.dev - if you don't sign up with a social login, you will need to enable 2fa. Then from the profile menu, "Manage Organisations" - create a "Project Jedi" organisation - this will be the owner of the packages (better than tying them to one person). Then create an API Key and set the packages owner to the "Project Jedi"  organisation.

Once the PR is merged, run the gitconfig.bat file - that installs a postcommit hook that will update the Jedi.JCL.dspec file with the current commit hash (adds traceability to packages).

Install the DPM client - https://delphi.dev/downloads

Open the DSpecCreator tool and open the Jedi.JCL.dspec - adjust the platforms as needed on the TargetPlatforms tab - if you change anything, save and commit the change and re-open the file in DspecCreator to pick up the new commit hash (the post commit hook updates the dspec file automatically).

If you have a code signing certificate available you can configure the Signing tab - (note that Azure Key Vault support is not tested yet).

On the Pack tab, set an output folder (anywhere) and click on Pack. This will generate the .dpkg files.

Next, on the Test tab, check the compiler versions you have available on your machine and click Test. This attempts to install the packages into the package cache (it removes them after the test).

If all goes well, the next step is to upload the packages. On the Upload tab, fill in your API Key and click upload.

Once packages are uploaded, it takes a few minutes before they show up on the site as they need to be checked, av scanned and then repository signed (which also counter signed the author signature if present).

I know this sounds complicated but most of it is first time setup stuff. If you need any help just let me know (allowing for timezone differences!).

If you prefer the command line, everything the dspeccreator can do (apart from create the dspec file) can also be done from the dpm cli tool.

Docs are here - https://docs.delphi.dev/

Note that DPM uses [Semantic Versioning](https://semver.org/) - so I used the latest release version as 2.8.9330 - obviously the repo has a bunch of commits since then so consider making a new release first ;) - with semantic versioning, you so need to be more strickt about when version numbers are bumped - in general - non interface changes, bump the patch, interfaces changes, bump minor, major or breaking changes, bump the major version. Semver also makes it really easy to create alpha or beta releases - e.g 3.0.0-alpha.1 3.0.0-beta.2 etc 

I know that some people do not like Semantic versioning - but that's probably because they tried to use it for an application - but for libraries it makes a lot of sense. 

Thx