### PR TITLE
Fix for two issues in the JCLDebug address to source lookup

### DIFF
--- a/jcl/source/windows/JclDebug.pas
+++ b/jcl/source/windows/JclDebug.pas
@@ -229,6 +229,7 @@ type
     VA: DWORD; // VA relative to (module base address + $10000)
     LineNumber: Integer;
     UnitName: PJclMapString;
+    SourceName: PJclMapString; // source file the line number was emitted for
   end;
 
   TJclMapScanner = class(TJclAbstractMapParser)
@@ -240,7 +241,7 @@ type
     FSourceNames: array of TJclMapProcName;
     FLineNumbersCnt: Integer;
     FLineNumberErrors: Integer;
-    FNewUnitFileName: PJclMapString;
+    FCurrentUnitFileName: PJclMapString;
     FCurrentUnitName: PJclMapString;
     FProcNamesCnt: Integer;
     FSegmentCnt: Integer;
@@ -248,6 +249,7 @@ type
     function IndexOfSegment(Addr: DWORD): Integer;
   protected
     function MAPAddrToVA(const Addr: DWORD): DWORD;
+    procedure BuildSourceNames;
     procedure ClassTableItem(const Address: TJclMapAddress; Len: Integer; SectionName, GroupName: PJclMapString); override;
     procedure SegmentItem(const Address: TJclMapAddress; Len: Integer; GroupName, UnitName: PJclMapString); override;
     function CanHandlePublicsByName: Boolean; override;
@@ -1887,6 +1889,80 @@ begin
     Result := Addr;
 end;
 
+procedure TJclMapScanner.BuildSourceNames;
+var
+  i, LCount, LSegIndex, LLastSegIndex, LNameEnd: Integer;
+  LPCurrentLine: PJclMapLineNumber;
+  LPMapProcName: PJclMapProcName;
+  LPLastSourceName: PJclMapString;
+  LLastName, LName, LUnitName: string;
+begin
+  LCount := 0;
+  LLastSegIndex := Low(Integer);
+  LPLastSourceName := nil;
+
+  for i := 0 to High(FLineNumbers) do
+  begin
+    LPCurrentLine := @FLineNumbers[i];
+
+    if LPCurrentLine.SourceName = nil then
+      Continue;
+
+    // SourceNameFromAddr rejects an entry that starts in another unit, so a crossing needs an entry
+    // of its own even when the source file has not changed.}
+    LSegIndex := IndexOfSegment(LPCurrentLine.VA);
+    if LSegIndex = LLastSegIndex then
+    begin
+      // One block shares one pointer, so this skips most line numbers without converting anything.
+      // Separate blocks for the same file need the name comparison.}
+      if LPCurrentLine.SourceName = LPLastSourceName then
+        Continue;
+
+      LName := MapStringToStr(LPCurrentLine.SourceName);
+      if LName = LLastName then
+      begin
+        LPLastSourceName := LPCurrentLine.SourceName;
+        Continue;
+      end;
+    end
+    else
+      LName := MapStringToStr(LPCurrentLine.SourceName);
+
+    // A unit's line numbers end one past its last instruction, which is the next unit's first address,
+    // so two units can claim one address and the sort does not order them - the segment does.  UnitName
+    // points at a "<unit>(<source file>) segment <section>" heading here rather than at a segment line,
+    // hence the manual split.
+    LUnitName := MapStringToStr(LPCurrentLine.UnitName);
+    LNameEnd := Pos('(', LUnitName);
+    if LNameEnd > 0 then
+      SetLength(LUnitName, LNameEnd - 1);
+    if (LCount > 0) and (FSourceNames[LCount - 1].VA = LPCurrentLine.VA) then
+    begin
+      if (LSegIndex < 0) or (LUnitName <> MapStringCacheToModuleName(FSegments[LSegIndex].UnitName)) then
+        Continue;
+
+      Dec(LCount);
+    end;
+
+    LLastSegIndex := LSegIndex;
+    LPLastSourceName := LPCurrentLine.SourceName;
+    LLastName := LName;
+
+    if LCount >= Length(FSourceNames) then
+      SetLength(FSourceNames, LCount * 2 + 256);
+
+    LPMapProcName := @FSourceNames[LCount];
+    LPMapProcName.Segment := LPCurrentLine.Segment;
+    LPMapProcName.VA := LPCurrentLine.VA;
+    LPMapProcName.ProcName.RawValue := LPLastSourceName;
+    LPMapProcName.ProcName.CachedValue := LName;
+
+    Inc(LCount);
+  end;
+
+  SetLength(FSourceNames, LCount);
+end;
+
 class function TJclMapScanner.MapStringCacheToFileName(
   var MapString: TJclMapStringCache): string;
 begin
@@ -1992,7 +2068,7 @@ end;
 
 procedure TJclMapScanner.LineNumbersItem(LineNumber: Integer; const Address: TJclMapAddress);
 var
-  SegIndex, C: Integer;
+  SegIndex: Integer;
   VA: DWORD;
   Added: Boolean;
 begin
@@ -2023,17 +2099,9 @@ begin
     FLineNumbers[FLineNumbersCnt].VA := VA;
     FLineNumbers[FLineNumbersCnt].LineNumber := LineNumber;
     FLineNumbers[FLineNumbersCnt].UnitName := FCurrentUnitName;
+    FLineNumbers[FLineNumbersCnt].SourceName := FCurrentUnitFileName;
     Inc(FLineNumbersCnt);
     Added := True;
-    if FNewUnitFileName <> nil then
-    begin
-      C := Length(FSourceNames);
-      SetLength(FSourceNames, C + 1);
-      FSourceNames[C].Segment := FSegmentClasses[SegIndex].Segment;
-      FSourceNames[C].VA := VA;
-      FSourceNames[C].ProcName.RawValue := FNewUnitFileName;
-      FNewUnitFileName := nil;
-    end;
     Break;
   end;
   if not Added then
@@ -2042,7 +2110,7 @@ end;
 
 procedure TJclMapScanner.LineNumberUnitItem(UnitName, UnitFileName: PJclMapString);
 begin
-  FNewUnitFileName := UnitFileName;
+  FCurrentUnitFileName := UnitFileName;
   FCurrentUnitName := UnitName;
 end;
 
@@ -2295,7 +2363,7 @@ begin
   if FProcNames <> nil then
     SortProcNames(PJclMapProcNameArray(FProcNames), 0, Length(FProcNames) - 1);
   SortDynArray(FSegments, SizeOf(FSegments[0]), Sort_MapSegment);
-  SortDynArray(FSourceNames, SizeOf(FSourceNames[0]), Sort_MapProcName);
+  BuildSourceNames;
 end;
 
 procedure TJclMapScanner.SegmentItem(const Address: TJclMapAddress; Len: Integer;
@@ -3096,15 +3164,9 @@ begin
     for I := 0 to Length(FSourceNames) - 1 do
       if IsSegmentStored(FSourceNames[I].Segment) then
       begin
-        // FSourceNames[] is sorted by VA, so if the source file name is the same as the previous
-        // we don't need to store it because the VA will be matched by the previous entry.
-        // This removes a lot of "Generics.Collections.pas" entries.
         S := MapStringCacheToStr(FSourceNames[I].ProcName);
-        if (I = 0) or (FSourceNames[I - 1].ProcName.CachedValue <> S) then
-        begin
-          WriteValueOfs(FSourceNames[I].VA, L1);
-          WriteValueOfs(AddWord(S), L2);
-        end;
+        WriteValueOfs(FSourceNames[I].VA, L1);
+        WriteValueOfs(AddWord(S), L2);
       end;
     WriteValue(MaxInt);
 
@@ -3546,21 +3608,13 @@ begin
   begin
     Inc(StartAddr, Value);
     if Addr < StartAddr then
-    begin
-      if ItemAddr < ModuleStartAddr then
-        Name := 0
-      else
-        Found := True;
       Break;
-    end
-    else
-    begin
-      ItemAddr := StartAddr;
-      ReadValue(P, Value);
-      Inc(Name, Value);
-    end;
+    ItemAddr := StartAddr;
+    ReadValue(P, Value);
+    Inc(Name, Value);
+    Found := True;
   end;
-  if Found then
+  if Found and (ItemAddr >= ModuleStartAddr) then
     Result := DataToStr(Name)
   else
     Result := '';


### PR DESCRIPTION
This pull request addresses two issues in the JCL Debug address to source lookup mechanism:

1) A source file name leaks across the rest of a unit. TJclMapScanner recorded only the first address of each MAP line-number block, and SourceNameFromAddr applies a name from its address to the next entry. Generic or inlined code from another file plants a block mid-unit, so everything after it is reported against that file. Worse under Win64, where dcc64 places such code near the start of a unit rather than the end.

2) The last source file name in the module is never reported. SourceNameFromAddr set Found only when the scan broke out early; when the match was the table's last entry the loop ended on the terminator and it returned ''. The last unit linked therefore lost its source file entirely.

In order to reproduce these issues, build and run the attached test case while ensuring it has embedded debug info (either via building it in the IDE with the JCL installed, or via MakeJclDbg). Note how addresses after the function that uses generics get misreported.

[JclDebugSourceNames.zip](https://github.com/user-attachments/files/31663622/JclDebugSourceNames.zip)
